### PR TITLE
Feat/ 인증 번호 전송하기 #44

### DIFF
--- a/wingle/build.gradle
+++ b/wingle/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'mysql:mysql-connector-java'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/wingle/build.gradle
+++ b/wingle/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/wingle/src/main/java/kr/co/wingle/common/config/MailConfig.java
+++ b/wingle/src/main/java/kr/co/wingle/common/config/MailConfig.java
@@ -12,4 +12,5 @@ public class MailConfig {
 	private String username;
 	private final String title = "윙글(Wingle) 이메일 인증코드";
 	private final String name = "wingle";
+	private final long validTime = 60 * 3L; // 3분
 }

--- a/wingle/src/main/java/kr/co/wingle/common/config/MailConfig.java
+++ b/wingle/src/main/java/kr/co/wingle/common/config/MailConfig.java
@@ -1,0 +1,15 @@
+package kr.co.wingle.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+
+@Getter
+@Configuration
+public class MailConfig {
+	@Value("${spring.mail.username}")
+	private String username;
+	private final String title = "윙글(Wingle) 이메일 인증코드";
+	private final String name = "wingle";
+}

--- a/wingle/src/main/java/kr/co/wingle/common/config/MailConfig.java
+++ b/wingle/src/main/java/kr/co/wingle/common/config/MailConfig.java
@@ -12,5 +12,5 @@ public class MailConfig {
 	private String username;
 	private final String title = "윙글(Wingle) 이메일 인증코드";
 	private final String name = "wingle";
-	private final long validTime = 60 * 3L; // 3분
+	private final long validTime = 1000 * 60 * 3L; // 3분
 }

--- a/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 	BAD_FILE_NAME(BAD_REQUEST, "파일 이름이 올바르지 않습니다."),
 	BAD_FILE_EXTENSION(BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
 	EMAIL_BAD_REQUEST(BAD_REQUEST, "이메일 형식이 유효하지 않습니다."),
+	EMAIL_SEND_FAIL(BAD_REQUEST, "이메일을 전송할 수 없습니다."),
 	DUPLICATE_EMAIL(BAD_REQUEST, "이미 가입된 유저입니다."),
 	BAD_PARAMETER(BAD_REQUEST, "요청 파라미터가 잘못되었습니다."),
 	BAD_PARAMETER_TYPE(BAD_REQUEST, "지원하지 않는 파라미터 형식입니다."),

--- a/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
@@ -15,6 +15,7 @@ public enum SuccessCode {
     LOGOUT_SUCCESS(OK, "로그아웃 성공"),
     ACCOUNT_READ_SUCCESS(OK, "계정 조회 성공"),
     TOKEN_REISSUE_SUCCESS(OK, "토큰 재발급 성공");
+	EMAIL_SEND_SUCCESS(OK, "이메일 인증코드 전송 성공");
 
     private final HttpStatus status;
     private final String message;

--- a/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
@@ -1,22 +1,23 @@
 package kr.co.wingle.common.constants;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import static org.springframework.http.HttpStatus.*;
+
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum SuccessCode {
-    EXAMPLE_SUCCESS(OK, "예시 성공"),
-    SIGNUP_SUCCESS(OK, "회원가입 성공"),
-    LOGIN_SUCCESS(OK, "로그인 성공"),
-    LOGOUT_SUCCESS(OK, "로그아웃 성공"),
-    ACCOUNT_READ_SUCCESS(OK, "계정 조회 성공"),
-    TOKEN_REISSUE_SUCCESS(OK, "토큰 재발급 성공");
+	EXAMPLE_SUCCESS(OK, "예시 성공"),
+	SIGNUP_SUCCESS(OK, "회원가입 성공"),
+	LOGIN_SUCCESS(OK, "로그인 성공"),
+	LOGOUT_SUCCESS(OK, "로그아웃 성공"),
+	ACCOUNT_READ_SUCCESS(OK, "계정 조회 성공"),
+	TOKEN_REISSUE_SUCCESS(OK, "토큰 재발급 성공"),
 	EMAIL_SEND_SUCCESS(OK, "이메일 인증코드 전송 성공");
 
-    private final HttpStatus status;
-    private final String message;
+	private final HttpStatus status;
+	private final String message;
 }

--- a/wingle/src/main/java/kr/co/wingle/member/AuthController.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthController.java
@@ -11,11 +11,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import kr.co.wingle.common.constants.SuccessCode;
 import kr.co.wingle.common.dto.ApiResponse;
-import kr.co.wingle.member.dto.MemberResponseDto;
-import kr.co.wingle.member.dto.TokenDto;
+import kr.co.wingle.member.dto.EmailRequestDto;
+import kr.co.wingle.member.dto.EmailResponseDto;
 import kr.co.wingle.member.dto.LoginRequestDto;
+import kr.co.wingle.member.dto.MemberResponseDto;
 import kr.co.wingle.member.dto.SignupRequestDto;
 import kr.co.wingle.member.dto.SignupResponseDto;
+import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.member.dto.TokenRequestDto;
 import lombok.RequiredArgsConstructor;
 
@@ -48,5 +50,11 @@ public class AuthController {
 	public ApiResponse<TokenDto> refresh(@RequestBody @Valid TokenRequestDto tokenRequestDto) {
 		TokenDto response = authService.reissue(tokenRequestDto);
 		return ApiResponse.success(SuccessCode.TOKEN_REISSUE_SUCCESS, response);
+	}
+
+	@PostMapping("/email")
+	public ApiResponse<EmailResponseDto> email(@RequestBody @Valid EmailRequestDto emailRequestDto) {
+		EmailResponseDto response = authService.sendEmailCode(emailRequestDto);
+		return ApiResponse.success(SuccessCode.EMAIL_SEND_SUCCESS, response);
 	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthService.java
@@ -3,6 +3,7 @@ package kr.co.wingle.member;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -12,18 +13,20 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import kr.co.wingle.common.constants.ErrorCode;
+import kr.co.wingle.common.exception.CustomException;
 import kr.co.wingle.common.exception.DuplicateException;
 import kr.co.wingle.common.exception.NotFoundException;
 import kr.co.wingle.common.jwt.TokenInfo;
-import kr.co.wingle.common.util.RedisUtil;
-import kr.co.wingle.member.dto.TokenDto;
-import kr.co.wingle.common.exception.CustomException;
 import kr.co.wingle.common.jwt.TokenProvider;
+import kr.co.wingle.common.util.RedisUtil;
 import kr.co.wingle.common.util.S3Util;
 import kr.co.wingle.common.util.SecurityUtil;
+import kr.co.wingle.member.dto.EmailRequestDto;
+import kr.co.wingle.member.dto.EmailResponseDto;
 import kr.co.wingle.member.dto.LoginRequestDto;
 import kr.co.wingle.member.dto.SignupRequestDto;
 import kr.co.wingle.member.dto.SignupResponseDto;
+import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.member.dto.TokenRequestDto;
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +39,9 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final S3Util s3Util;
 	private final RedisUtil redisUtil;
+
+	@Autowired
+	MailService mailService;
 
 	@Transactional
 	public SignupResponseDto signup(SignupRequestDto request) {
@@ -121,5 +127,11 @@ public class AuthService {
 
 	private String uploadIdCardImage(MultipartFile idCardImage) {
 		return s3Util.idCardImageUpload(idCardImage);
+	}
+
+	public EmailResponseDto sendEmailCode(EmailRequestDto emailRequestDto) {
+		String to = emailRequestDto.getEmail();
+		String certificationKey = mailService.sendEmailCode(to);
+		return EmailResponseDto.of(certificationKey);
 	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/MailService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/MailService.java
@@ -29,12 +29,12 @@ public class MailService {
 	public String sendEmailCode(String to) {
 		final String certificationKey = createCode();
 		try {
-			MimeMessage message = createMessage(to, certificationKey);
+			final String code = createCode();
 			emailSender.send(message);
 		} catch (MailException | MessagingException | UnsupportedEncodingException es) {
 			throw new CustomException(ErrorCode.EMAIL_SEND_FAIL);
 		}
-		return certificationKey;
+		return to;
 	}
 
 	private String createCode() {

--- a/wingle/src/main/java/kr/co/wingle/member/MailService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/MailService.java
@@ -8,7 +8,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -23,10 +22,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class MailService {
-	@Autowired
-	MailConfig mailConfig;
-	@Autowired
-	JavaMailSender emailSender;
+	private final MailConfig mailConfig;
+	private final JavaMailSender emailSender;
 	private final SpringTemplateEngine templateEngine;
 
 	public String sendEmailCode(String to) {

--- a/wingle/src/main/java/kr/co/wingle/member/MailService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/MailService.java
@@ -1,0 +1,72 @@
+package kr.co.wingle.member;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+
+import kr.co.wingle.common.config.MailConfig;
+import kr.co.wingle.common.constants.ErrorCode;
+import kr.co.wingle.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+	@Autowired
+	MailConfig mailConfig;
+	@Autowired
+	JavaMailSender emailSender;
+	private final SpringTemplateEngine templateEngine;
+
+	public String sendEmailCode(String to) {
+		final String certificationKey = createCode();
+		try {
+			MimeMessage message = createMessage(to, certificationKey);
+			emailSender.send(message);
+		} catch (MailException | MessagingException | UnsupportedEncodingException es) {
+			throw new CustomException(ErrorCode.EMAIL_SEND_FAIL);
+		}
+		return certificationKey;
+	}
+
+	private String createCode() {
+		final int CODE_LENGTH = 4;
+		String code = "";
+		Random random = new Random();
+		for (int i = 0; i < CODE_LENGTH; i++) {
+			code += random.nextInt(10); // 0~9
+		}
+		return code;
+	}
+
+	private MimeMessage createMessage(String to, String code) throws MessagingException, UnsupportedEncodingException {
+		final String title = mailConfig.getTitle();
+		final String from = mailConfig.getUsername();
+		final String fromName = mailConfig.getName();
+
+		MimeMessage message = emailSender.createMimeMessage();
+		message.addRecipients(RecipientType.TO, to);
+		message.setSubject(title);
+		message.setText(setContext(code), "utf-8", "html");
+		message.setFrom(new InternetAddress(from, fromName));
+
+		return message;
+	}
+
+	private String setContext(String code) {
+		Context context = new Context();
+		context.setVariable("code", code);
+		return templateEngine.process("mail", context); //mail.html
+	}
+}

--- a/wingle/src/main/java/kr/co/wingle/member/MailService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/MailService.java
@@ -17,19 +17,22 @@ import org.thymeleaf.spring5.SpringTemplateEngine;
 import kr.co.wingle.common.config.MailConfig;
 import kr.co.wingle.common.constants.ErrorCode;
 import kr.co.wingle.common.exception.CustomException;
+import kr.co.wingle.common.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MailService {
 	private final MailConfig mailConfig;
+	private final RedisUtil redisUtil;
 	private final JavaMailSender emailSender;
 	private final SpringTemplateEngine templateEngine;
 
 	public String sendEmailCode(String to) {
-		final String certificationKey = createCode();
 		try {
 			final String code = createCode();
+			redisUtil.setDataExpire(to, code, mailConfig.getValidTime());
+			MimeMessage message = createMessage(to, code);
 			emailSender.send(message);
 		} catch (MailException | MessagingException | UnsupportedEncodingException es) {
 			throw new CustomException(ErrorCode.EMAIL_SEND_FAIL);

--- a/wingle/src/main/java/kr/co/wingle/member/dto/EmailRequestDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/EmailRequestDto.java
@@ -1,0 +1,16 @@
+package kr.co.wingle.member.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailRequestDto {
+	@Email
+	@NotBlank(message = "이메일이 없습니다.")
+	private String email;
+}

--- a/wingle/src/main/java/kr/co/wingle/member/dto/EmailResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/EmailResponseDto.java
@@ -1,0 +1,17 @@
+package kr.co.wingle.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailResponseDto {
+	private String certificationKey;
+
+	public static EmailResponseDto of(String certificationKey) {
+		EmailResponseDto emailResponseDto = new EmailResponseDto();
+		emailResponseDto.certificationKey = certificationKey;
+		return emailResponseDto;
+	}
+}

--- a/wingle/src/main/resources/templates/mail.html
+++ b/wingle/src/main/resources/templates/mail.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+    <h1> 안녕하세요.</h1>
+    <h1> 윙글(Wingle) 입니다.</h1>
+    <br>
+    <p>아래 코드를 복사해 입력해주세요
+    <p>
+    <div align="center" style="border:1px solid black; font-family:verdana;">
+        <h3 style="color:blue"> 회원가입 인증 코드 입니다. </h3>
+        <div style="font-size:130%" th:text="${code}"></div>
+    </div>
+    <br/>
+</div>
+</body>
+</html>

--- a/wingle/src/test/java/kr/co/wingle/member/AuthServiceTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/AuthServiceTest.java
@@ -157,4 +157,8 @@ class AuthServiceTest {
 		redisUtil.deleteData(key);
 	}
 
+	@Test
+	void 이메일로_인증번호_전송_성공() {
+
+	}
 }


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [X] 이 프로젝트의 코드 스타일을 따르나요?
- [X] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [X] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 사용자 이메일로 4자리 숫자(0~9) 인증번호를 전송하는 API를 구현하였습니다.
- 이메일 전송과 관련하여 application.yml 파일이 수정되었습니다.
- api문서도 수정되었습니다. 
    - key를 인증코드->이메일로 변경하였고, 타입을 Number -> String으로 변경하였습니다.
    - 인증코드를 프론트로 넘길 경우 보안의 문제가 생길 수 있으므로 key-value쌍을 이메일-인증코드 쌍으로 하여 redis에 저장하였고 프론트에게 이메일을 전달합니다. 따라서 프론트에 인증코드를 노출하지 않을 수 있습니다. 
    - 인증코드는 3분간 유효하도록 설정하였습니다. 설정은 MailConfig에서 변경할 수 있습니다.

## 💻 실행결과
- postman
![image](https://user-images.githubusercontent.com/56223389/219268318-c597cdd1-d3e0-46cb-8fc8-c3f711306391.png)

- 받는 사람
![image](https://user-images.githubusercontent.com/56223389/219268668-47e2143b-368a-4cfd-8113-c1b47351aae2.png)


- 보내는 사람
![image](https://user-images.githubusercontent.com/56223389/219268698-3be2f0c3-f6a0-4730-8b16-2d45226b2a4e.png)

- redis
![image](https://user-images.githubusercontent.com/56223389/219268423-0df772d8-928c-4c69-a8c8-04d1b45e26b2.png)



resolved: #44
