### PR TITLE
Feat/인증 번호 확인하기 #47

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
 	BAD_FILE_EXTENSION(BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
 	EMAIL_BAD_REQUEST(BAD_REQUEST, "이메일 형식이 유효하지 않습니다."),
 	EMAIL_SEND_FAIL(BAD_REQUEST, "이메일을 전송할 수 없습니다."),
+	NO_EMAIL_CODE(BAD_REQUEST, "해당 이메일에 유효한 인증정보가 없습니다."),
+	INCONSISTENT_CODE(BAD_REQUEST, "인증정보가 일치하지 않습니다."),
 	DUPLICATE_EMAIL(BAD_REQUEST, "이미 가입된 유저입니다."),
 	BAD_PARAMETER(BAD_REQUEST, "요청 파라미터가 잘못되었습니다."),
 	BAD_PARAMETER_TYPE(BAD_REQUEST, "지원하지 않는 파라미터 형식입니다."),

--- a/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
@@ -16,7 +16,8 @@ public enum SuccessCode {
 	LOGOUT_SUCCESS(OK, "로그아웃 성공"),
 	ACCOUNT_READ_SUCCESS(OK, "계정 조회 성공"),
 	TOKEN_REISSUE_SUCCESS(OK, "토큰 재발급 성공"),
-	EMAIL_SEND_SUCCESS(OK, "이메일 인증코드 전송 성공");
+	EMAIL_SEND_SUCCESS(OK, "이메일 인증코드 전송 성공"),
+	EMAIL_CERTIFICATION_SUCCESS(OK, "이메일 인증 성공");
 
 	private final HttpStatus status;
 	private final String message;

--- a/wingle/src/main/java/kr/co/wingle/member/AuthController.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import kr.co.wingle.common.constants.SuccessCode;
 import kr.co.wingle.common.dto.ApiResponse;
+import kr.co.wingle.member.dto.CertificationRequestDto;
+import kr.co.wingle.member.dto.CertificationResponseDto;
 import kr.co.wingle.member.dto.EmailRequestDto;
 import kr.co.wingle.member.dto.EmailResponseDto;
 import kr.co.wingle.member.dto.LoginRequestDto;
@@ -56,5 +58,12 @@ public class AuthController {
 	public ApiResponse<EmailResponseDto> email(@RequestBody @Valid EmailRequestDto emailRequestDto) {
 		EmailResponseDto response = authService.sendEmailCode(emailRequestDto);
 		return ApiResponse.success(SuccessCode.EMAIL_SEND_SUCCESS, response);
+	}
+
+	@PostMapping("/email/certification")
+	public ApiResponse<CertificationResponseDto> email(
+		@RequestBody @Valid CertificationRequestDto certificationRequestDto) {
+		CertificationResponseDto response = authService.checkEmailAndCode(certificationRequestDto);
+		return ApiResponse.success(SuccessCode.EMAIL_CERTIFICATION_SUCCESS, response);
 	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthService.java
@@ -21,6 +21,8 @@ import kr.co.wingle.common.jwt.TokenProvider;
 import kr.co.wingle.common.util.RedisUtil;
 import kr.co.wingle.common.util.S3Util;
 import kr.co.wingle.common.util.SecurityUtil;
+import kr.co.wingle.member.dto.CertificationRequestDto;
+import kr.co.wingle.member.dto.CertificationResponseDto;
 import kr.co.wingle.member.dto.EmailRequestDto;
 import kr.co.wingle.member.dto.EmailResponseDto;
 import kr.co.wingle.member.dto.LoginRequestDto;
@@ -133,5 +135,16 @@ public class AuthService {
 		String to = emailRequestDto.getEmail();
 		String certificationKey = mailService.sendEmailCode(to);
 		return EmailResponseDto.of(certificationKey);
+	}
+
+	public CertificationResponseDto checkEmailAndCode(CertificationRequestDto certificationRequestDto) {
+		String email = certificationRequestDto.getCertificationKey();
+		String inputCode = certificationRequestDto.getCertificationCode();
+		String code = redisUtil.getData(email);
+		if (code == null)
+			throw new CustomException(ErrorCode.NO_EMAIL_CODE);
+		if (!code.equals(inputCode))
+			throw new CustomException(ErrorCode.INCONSISTENT_CODE);
+		return CertificationResponseDto.of(true);
 	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/dto/CertificationRequestDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/CertificationRequestDto.java
@@ -1,0 +1,18 @@
+package kr.co.wingle.member.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CertificationRequestDto {
+	@Email
+	@NotBlank(message = "이메일이 없습니다.")
+	String certificationKey;
+	@NotBlank(message = "인증정보가 없습니다.")
+	String certificationCode;
+}

--- a/wingle/src/main/java/kr/co/wingle/member/dto/CertificationResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/CertificationResponseDto.java
@@ -1,0 +1,17 @@
+package kr.co.wingle.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CertificationResponseDto {
+	private boolean isAvailable;
+
+	public static CertificationResponseDto of(boolean isAvailable) {
+		CertificationResponseDto certificationResponseDto = new CertificationResponseDto();
+		certificationResponseDto.isAvailable = isAvailable;
+		return certificationResponseDto;
+	}
+}

--- a/wingle/src/test/java/kr/co/wingle/member/AuthServiceTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/AuthServiceTest.java
@@ -161,4 +161,14 @@ class AuthServiceTest {
 	void 이메일로_인증번호_전송_성공() {
 
 	}
+
+	@Test
+	void 인증번호_일치_검사_성공() {
+
+	}
+
+	@Test
+	void 인증번호_불일치_검사_실패() {
+
+	}
 }


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [X] 이 프로젝트의 코드 스타일을 따르나요?
- [X] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [X] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 이메일 인증시, 사용자가 입력한 인증정보(번호)가 올바른지 확인하는 API입니다.
- (성공) 인증정보가 일치하면 true을 반환합니다.
- (실패) 인증정보를 받지 않은 이메일을 입력했거나, 인증정보가 만료된 경우 "해당 이메일에 유효한 인증정보가 없습니다." 로 응답합니다.
- (실패) 인증번호가 틀린 경우 "인증정보가 일치하지 않습니다."로 응답합니다.

## 💻 실행결과
- postman
- 인증정보가 2973이었을 때
- 일치하는 인증정보를 입력했을 경우
![image](https://user-images.githubusercontent.com/56223389/219321457-2ace2986-1ccd-46a8-ba95-bb5c06d898c8.png)

- 일치하지 않는 인증정보를 입력했을 경우
![image](https://user-images.githubusercontent.com/56223389/219321656-ef948232-5d4c-4219-b00a-6d9a90e80a62.png)

- 인증정보를 받지 않은 이메일이 입력된 경우
![image](https://user-images.githubusercontent.com/56223389/219322642-fa72463d-ae1d-466e-b562-40f05cc0a55c.png)

- 인증정보 재전송 후, 이전에 발송했던 인증정보를 다시 입력해도 일치하지 않음 (재전송된 인증정보로 갱신되었기 때문)
![image](https://user-images.githubusercontent.com/56223389/219323234-5dac68db-a957-4f4c-8d7e-5531cb5f0a3c.png)

resolved: #47