### PR TITLE
[feat] 로그아웃 API

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
 	/* 404 NOT_FOUND: 리소스를 찾을 수 없음 */
 	DATA_NOT_FOUND(NOT_FOUND, "해당 데이터를 찾을 수 없습니다."),
 	USER_NOT_FOUND(NOT_FOUND, "유저를 찾을 수 없습니다."),
-	REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃된 사용자입니다. 다시 로그인해주세요."),
+	TOKEN_NOT_FOUND(NOT_FOUND, "다시 로그인해주세요."),
 
 	/* 500 INTERNAL_SERVER_ERROR : 서버 오류 */
 	FILE_UPLOAD_FAIL(INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),

--- a/wingle/src/main/java/kr/co/wingle/common/jwt/JwtFilter.java
+++ b/wingle/src/main/java/kr/co/wingle/common/jwt/JwtFilter.java
@@ -23,7 +23,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		FilterChain filterChain) throws IOException, ServletException {
 		String jwt = resolveToken(request);
 
-		if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt, request)) {
+		if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt) && !tokenProvider.isLogout(jwt)) {
 			Authentication authentication = tokenProvider.getAuthentication(jwt);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 		}

--- a/wingle/src/main/java/kr/co/wingle/common/util/RedisUtil.java
+++ b/wingle/src/main/java/kr/co/wingle/common/util/RedisUtil.java
@@ -14,7 +14,8 @@ public class RedisUtil {
 
 	private final RedisTemplate<String, String> redisTemplate;
 
-	public static final String PREFIX_REFRESH_TOKEN = "REFRESH_TOKEN_";
+	public static final String PREFIX_REFRESH_TOKEN = "REFRESH_TOKEN:";
+	public static final String PREFIX_LOGOUT = "LOGOUT:";
 
 	public String getData(String key) {
 		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();

--- a/wingle/src/main/java/kr/co/wingle/member/AuthController.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthController.java
@@ -60,6 +60,7 @@ public class AuthController {
 	public ApiResponse<Object> logout(@RequestBody @Valid LogoutRequestDto logoutRequestDto) {
 		authService.logout(logoutRequestDto);
 		return ApiResponse.success(SuccessCode.LOGOUT_SUCCESS, null);
+	}
 
 	@PostMapping("/email")
 	public ApiResponse<EmailResponseDto> email(@RequestBody @Valid EmailRequestDto emailRequestDto) {

--- a/wingle/src/main/java/kr/co/wingle/member/AuthController.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthController.java
@@ -6,11 +6,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.co.wingle.common.constants.SuccessCode;
 import kr.co.wingle.common.dto.ApiResponse;
+import kr.co.wingle.member.dto.LogoutRequestDto;
 import kr.co.wingle.member.dto.MemberResponseDto;
 import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.member.dto.LoginRequestDto;
@@ -48,5 +50,11 @@ public class AuthController {
 	public ApiResponse<TokenDto> refresh(@RequestBody @Valid TokenRequestDto tokenRequestDto) {
 		TokenDto response = authService.reissue(tokenRequestDto);
 		return ApiResponse.success(SuccessCode.TOKEN_REISSUE_SUCCESS, response);
+	}
+
+	@GetMapping("/logout")
+	public ApiResponse<Object> logout(@RequestBody @Valid LogoutRequestDto logoutRequestDto) {
+		authService.logout(logoutRequestDto);
+		return ApiResponse.success(SuccessCode.LOGOUT_SUCCESS, null);
 	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthService.java
@@ -6,9 +6,11 @@ import java.util.regex.Pattern;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import kr.co.wingle.common.constants.ErrorCode;
@@ -16,6 +18,7 @@ import kr.co.wingle.common.exception.DuplicateException;
 import kr.co.wingle.common.exception.NotFoundException;
 import kr.co.wingle.common.jwt.TokenInfo;
 import kr.co.wingle.common.util.RedisUtil;
+import kr.co.wingle.member.dto.LogoutRequestDto;
 import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.common.exception.CustomException;
 import kr.co.wingle.common.jwt.TokenProvider;
@@ -84,6 +87,24 @@ public class AuthService {
 
 		Authentication authentication = tokenProvider.getAuthentication(refreshToken);
 		return getRedisTokenKey(authentication);
+	}
+
+	@Transactional
+	public void logout(LogoutRequestDto logoutRequestDto) {
+		String accessToken = logoutRequestDto.getAccessToken();
+		if (!tokenProvider.validateToken(accessToken)) {
+			throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
+		}
+
+		String refreshTokenKey = RedisUtil.PREFIX_REFRESH_TOKEN + logoutRequestDto.getRefreshToken();
+
+		String refreshToken = redisUtil.getData(refreshTokenKey);
+		if (refreshToken == null) {
+			throw new NotFoundException(ErrorCode.TOKEN_NOT_FOUND);
+		}
+		redisUtil.deleteData(refreshTokenKey);
+
+		redisUtil.setDataExpire(RedisUtil.PREFIX_LOGOUT + accessToken, "logout", TokenInfo.ACCESS_TOKEN_EXPIRE_TIME);
 	}
 
 	private TokenDto getRedisTokenKey(Authentication authentication) {

--- a/wingle/src/main/java/kr/co/wingle/member/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/AuthService.java
@@ -78,7 +78,7 @@ public class AuthService {
 		String key = RedisUtil.PREFIX_REFRESH_TOKEN + tokenRequestDto.getRefreshToken();
 		String refreshToken = redisUtil.getData(key);
 		if (refreshToken == null) {
-			throw new NotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+			throw new NotFoundException(ErrorCode.TOKEN_NOT_FOUND);
 		}
 		redisUtil.deleteData(key);
 

--- a/wingle/src/main/java/kr/co/wingle/member/dto/LogoutRequestDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/LogoutRequestDto.java
@@ -1,0 +1,24 @@
+package kr.co.wingle.member.dto;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LogoutRequestDto {
+	@NotBlank
+	private String accessToken;
+
+	@NotBlank
+	private String refreshToken;
+
+	public static LogoutRequestDto of(String accessToken, String refreshToken) {
+		LogoutRequestDto logoutRequestDto = new LogoutRequestDto();
+		logoutRequestDto.accessToken = accessToken;
+		logoutRequestDto.refreshToken = refreshToken;
+		return logoutRequestDto;
+	}
+}

--- a/wingle/src/test/java/kr/co/wingle/member/AuthControllerTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/AuthControllerTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.wingle.common.constants.SuccessCode;
 import kr.co.wingle.common.dto.ApiResponse;
 import kr.co.wingle.member.dto.LoginRequestDto;
+import kr.co.wingle.member.dto.LogoutRequestDto;
 import kr.co.wingle.member.dto.MemberResponseDto;
 import kr.co.wingle.member.dto.SignupRequestDto;
 import kr.co.wingle.member.dto.SignupResponseDto;
@@ -133,6 +134,22 @@ class AuthControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(content().string(
 				mapper.writeValueAsString(ApiResponse.success(SuccessCode.TOKEN_REISSUE_SUCCESS, tokenDto))
+			))
+			.andDo(print());
+	}
+
+	@Test
+	void 로그아웃() throws Exception {
+		LogoutRequestDto requestDto = LogoutRequestDto.of("accessToken", "refreshToken");
+
+		MockHttpServletRequestBuilder builder = get("/api/v1/auth/logout")
+			.content(mapper.writeValueAsString(requestDto))
+			.contentType(MediaType.APPLICATION_JSON);
+
+		mockMvc.perform(builder)
+			.andExpect(status().isOk())
+			.andExpect(content().string(
+				mapper.writeValueAsString(ApiResponse.success(SuccessCode.LOGOUT_SUCCESS, null))
 			))
 			.andDo(print());
 	}

--- a/wingle/src/test/java/kr/co/wingle/member/AuthServiceTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/AuthServiceTest.java
@@ -4,7 +4,9 @@ import static kr.co.wingle.member.MemberTemplate.*;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -14,12 +16,14 @@ import kr.co.wingle.common.exception.DuplicateException;
 import kr.co.wingle.common.exception.NotFoundException;
 import kr.co.wingle.common.util.RedisUtil;
 import kr.co.wingle.member.dto.LoginRequestDto;
+import kr.co.wingle.member.dto.LogoutRequestDto;
 import kr.co.wingle.member.dto.SignupRequestDto;
 import kr.co.wingle.member.dto.SignupResponseDto;
 import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.member.dto.TokenRequestDto;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @WithMockUser(value = EMAIL, password = PASSWORD)
 class AuthServiceTest {
 	@Autowired
@@ -31,8 +35,9 @@ class AuthServiceTest {
 	@Autowired
 	private RedisUtil redisUtil;
 
+	@BeforeAll
 	@AfterEach
-	void deleteMember() {
+	void cleanUp() {
 		memberRepository.deleteAll();
 	}
 
@@ -99,7 +104,7 @@ class AuthServiceTest {
 		TokenDto response = authService.login(requestDto);
 
 		//then
-		String key = PREFIX_REFRESH_TOKEN + response.getRefreshToken();
+		String key = RedisUtil.PREFIX_REFRESH_TOKEN + response.getRefreshToken();
 		String refreshToken = redisUtil.getData(key);
 
 		assertThat(response.getAccessToken()).isNotNull();
@@ -122,7 +127,7 @@ class AuthServiceTest {
 
 		//when
 		TokenDto response = authService.reissue(requestDto);
-		String key = PREFIX_REFRESH_TOKEN + response.getRefreshToken();
+		String key = RedisUtil.PREFIX_REFRESH_TOKEN + response.getRefreshToken();
 		String refreshToken = redisUtil.getData(key);
 
 		//then
@@ -132,7 +137,7 @@ class AuthServiceTest {
 
 		//teardown
 		redisUtil.deleteData(key);
-		key = PREFIX_REFRESH_TOKEN + tokenDto.getRefreshToken();
+		key = RedisUtil.PREFIX_REFRESH_TOKEN + tokenDto.getRefreshToken();
 		redisUtil.deleteData(key);
 
 	}
@@ -150,11 +155,52 @@ class AuthServiceTest {
 
 		//then
 		assertThatThrownBy(() -> authService.reissue(requestDto)).isInstanceOf(NotFoundException.class)
-			.hasMessage(ErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage());
+			.hasMessage(ErrorCode.TOKEN_NOT_FOUND.getMessage());
 
 		//teardown
-		String key = PREFIX_REFRESH_TOKEN + tokenDto.getRefreshToken();
+		String key = RedisUtil.PREFIX_REFRESH_TOKEN + tokenDto.getRefreshToken();
 		redisUtil.deleteData(key);
 	}
 
+	@Test
+	void 로그아웃() throws Exception {
+		//given
+		Member member = makeTestMember();
+		memberRepository.save(member);
+		LoginRequestDto loginRequestDto = LoginRequestDto.of(EMAIL, PASSWORD);
+		TokenDto tokenDto = authService.login(loginRequestDto);
+		LogoutRequestDto requestDto = LogoutRequestDto.of(tokenDto.getAccessToken(), tokenDto.getRefreshToken());
+
+		//when
+		authService.logout(requestDto);
+
+		//then
+		String logoutAccessToken = redisUtil.getData(RedisUtil.PREFIX_LOGOUT + requestDto.getAccessToken());
+		String logoutRefreshToken = redisUtil.getData(RedisUtil.PREFIX_REFRESH_TOKEN + requestDto.getRefreshToken());
+		assertThat(logoutAccessToken).isEqualTo("logout");
+		assertThat(logoutRefreshToken).isNull();
+
+		//teardown
+		redisUtil.deleteData(RedisUtil.PREFIX_LOGOUT + requestDto.getAccessToken());
+	}
+
+	@Test
+	void 로그아웃_실패() throws Exception {
+		//given
+		Member member = makeTestMember();
+		memberRepository.save(member);
+		LoginRequestDto loginRequestDto = LoginRequestDto.of(EMAIL, PASSWORD);
+		TokenDto tokenDto = authService.login(loginRequestDto);
+		LogoutRequestDto requestDto = LogoutRequestDto.of(tokenDto.getAccessToken(), tokenDto.getRefreshToken());
+
+		//when
+		authService.logout(requestDto);
+
+		//then
+		assertThatThrownBy(() -> authService.logout(requestDto)).isInstanceOf(NotFoundException.class)
+			.hasMessage(ErrorCode.TOKEN_NOT_FOUND.getMessage());
+
+		//teardown
+		redisUtil.deleteData(RedisUtil.PREFIX_LOGOUT + requestDto.getAccessToken());
+	}
 }

--- a/wingle/src/test/java/kr/co/wingle/member/MemberTemplate.java
+++ b/wingle/src/test/java/kr/co/wingle/member/MemberTemplate.java
@@ -15,7 +15,6 @@ public class MemberTemplate {
 	public static final String NICKNAME = "nickname";
 	public static final boolean GENDER = true;
 	public static final String NATION = "KR";
-	public static final String PREFIX_REFRESH_TOKEN = "REFRESH_TOKEN_";
 
 	private static final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 테스트 코드가 잘 통과되나요?
- [x] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [x] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 로그아웃 요청 시, 요청한 유저의 accessToken을 Redis에 블랙리스트로 저장하고, refreshToken은 지웁니다. Redis에 저장할 때 PREFIX는 LOGOUT: 으로 지정했습니다.
    <img width="1479" alt="image" src="https://user-images.githubusercontent.com/73515587/219382200-b00cf8bc-4828-485e-8790-af99fc3e2c72.png">
- 블랙리스트로 저장된 accessToken을 헤더로 넣어 API를 요청할 시, USER_NOT_FOUND 응답을 내보냅니다.

resolved: #37 
