### PR TITLE
[feat] 수락 대기 목록 조회 API

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 	UNAUTHORIZED_USER(UNAUTHORIZED, "만료되었거나 잘못된 토큰입니다. 토큰을 확인해주세요."),
 
 	/* 403 FORBIDDEN: 권한 없음 */
+	FORBIDDEN_USER(FORBIDDEN, "접근 권한이 없는 유저입니다."),
 
 	/* 404 NOT_FOUND: 리소스를 찾을 수 없음 */
 	DATA_NOT_FOUND(NOT_FOUND, "해당 데이터를 찾을 수 없습니다."),

--- a/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
+++ b/wingle/src/main/java/kr/co/wingle/common/constants/SuccessCode.java
@@ -16,7 +16,8 @@ public enum SuccessCode {
 	LOGOUT_SUCCESS(OK, "로그아웃 성공"),
 	ACCOUNT_READ_SUCCESS(OK, "계정 조회 성공"),
 	TOKEN_REISSUE_SUCCESS(OK, "토큰 재발급 성공"),
-	EMAIL_SEND_SUCCESS(OK, "이메일 인증코드 전송 성공");
+	EMAIL_SEND_SUCCESS(OK, "이메일 인증코드 전송 성공"),
+	WAITING_LIST_READ_SUCCESS(OK, "수락 대기 목록 조회 성공");
 
 	private final HttpStatus status;
 	private final String message;

--- a/wingle/src/main/java/kr/co/wingle/common/exception/ForbiddenException.java
+++ b/wingle/src/main/java/kr/co/wingle/common/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package kr.co.wingle.common.exception;
+
+import kr.co.wingle.common.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ForbiddenException extends RuntimeException {
+	private final ErrorCode code;
+
+	public ForbiddenException(ErrorCode code) {
+		super(code.getMessage());
+		this.code = code;
+	}
+}

--- a/wingle/src/main/java/kr/co/wingle/common/exception/RestExceptionHandler.java
+++ b/wingle/src/main/java/kr/co/wingle/common/exception/RestExceptionHandler.java
@@ -70,6 +70,13 @@ public class RestExceptionHandler {
 		return ApiResponse.error(exception.getCode());
 	}
 
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	@ExceptionHandler(ForbiddenException.class)
+	public ApiResponse<Object> handlerForbiddenException(ForbiddenException exception, HttpServletRequest request) {
+		logInfo(request, exception.getCode().getStatus(), exception.getMessage());
+		return ApiResponse.error(exception.getCode());
+	}
+
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(Exception.class)
 	public ApiResponse<Object> unhandledExceptionHandler(Exception exception, HttpServletRequest request) {

--- a/wingle/src/main/java/kr/co/wingle/member/MemberController.java
+++ b/wingle/src/main/java/kr/co/wingle/member/MemberController.java
@@ -1,12 +1,41 @@
 package kr.co.wingle.member;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import kr.co.wingle.common.constants.ErrorCode;
+import kr.co.wingle.common.constants.SuccessCode;
+import kr.co.wingle.common.dto.ApiResponse;
+import kr.co.wingle.common.exception.ForbiddenException;
+import kr.co.wingle.member.dto.WaitingListResponseDto;
+import kr.co.wingle.member.entity.Authority;
+import kr.co.wingle.member.entity.Member;
+import kr.co.wingle.member.service.AuthService;
 import kr.co.wingle.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequestMapping("api/v1/admin")
 @RequiredArgsConstructor
 public class MemberController {
 	private final MemberService memberService;
+	private final AuthService authService;
+
+	@GetMapping("/list/waiting/{page}")
+	public ApiResponse<List<WaitingListResponseDto>> waitingList(@PathVariable int page) {
+		checkAdminAccount();
+		List<WaitingListResponseDto> response = memberService.getWaitingList(page);
+		return ApiResponse.success(SuccessCode.WAITING_LIST_READ_SUCCESS, response);
+	}
+
+	private void checkAdminAccount() {
+		Member member = authService.findMember();
+		if (member.getAuthority() == Authority.ROLE_USER) {
+			throw new ForbiddenException(ErrorCode.FORBIDDEN_USER);
+		}
+	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/MemberRepository.java
+++ b/wingle/src/main/java/kr/co/wingle/member/MemberRepository.java
@@ -1,7 +1,9 @@
 package kr.co.wingle.member;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.co.wingle.member.entity.Member;
@@ -10,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByEmail(String email);
 
 	Optional<Member> findByEmail(String email);
+
+	List<Member> findAllByPermissionOrderByCreatedTimeDesc(int permission, Pageable pageable);
 }

--- a/wingle/src/main/java/kr/co/wingle/member/dto/WaitingListResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/WaitingListResponseDto.java
@@ -1,0 +1,25 @@
+package kr.co.wingle.member.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WaitingListResponseDto {
+	private Long userId;
+	private LocalDateTime createdTime;
+	private String name;
+	private String nation;
+
+	public static WaitingListResponseDto of(Long userId, LocalDateTime createdTime, String name, String nation) {
+		WaitingListResponseDto waitingListResponseDto = new WaitingListResponseDto();
+		waitingListResponseDto.userId = userId;
+		waitingListResponseDto.createdTime = createdTime;
+		waitingListResponseDto.name = name;
+		waitingListResponseDto.nation = nation;
+		return waitingListResponseDto;
+	}
+}

--- a/wingle/src/main/java/kr/co/wingle/member/service/MemberService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/MemberService.java
@@ -1,12 +1,37 @@
 package kr.co.wingle.member.service;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.wingle.common.constants.ErrorCode;
+import kr.co.wingle.common.exception.CustomException;
+import kr.co.wingle.common.exception.ForbiddenException;
+import kr.co.wingle.common.exception.NotFoundException;
 import kr.co.wingle.member.MemberRepository;
+import kr.co.wingle.member.dto.WaitingListResponseDto;
+import kr.co.wingle.member.entity.Authority;
+import kr.co.wingle.member.entity.Member;
+import kr.co.wingle.member.entity.Permission;
+import kr.co.wingle.profile.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 	private final MemberRepository memberRepository;
+	private final ProfileRepository profileRepository;
+
+	@Transactional
+	public List<WaitingListResponseDto> getWaitingList(int page) {
+		PageRequest pageRequest = PageRequest.of(page, 15);
+
+		return memberRepository.findAllByPermissionOrderByCreatedTimeDesc(Permission.WAIT.getStatus(), pageRequest)
+			.stream().map(member -> {
+				String nation = profileRepository.findNationByMember(member);
+				return WaitingListResponseDto.of(member.getId(), member.getCreatedTime(), member.getName(), nation);
+			}).toList();
+	}
 }

--- a/wingle/src/main/java/kr/co/wingle/profile/Profile.java
+++ b/wingle/src/main/java/kr/co/wingle/profile/Profile.java
@@ -2,11 +2,15 @@ package kr.co.wingle.profile;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.ColumnDefault;
 
 import kr.co.wingle.common.entity.BaseEntity;
+import kr.co.wingle.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +21,10 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile extends BaseEntity {
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
 
 	@Column(nullable = false)
 	private String nickname;
@@ -32,13 +40,18 @@ public class Profile extends BaseEntity {
 	@Setter
 	private boolean registration;
 
-	public static Profile createProfile(String nickname, String introduction, boolean gender, boolean registration) {
+	@Column(nullable = false)
+	private String nation;
+
+	public static Profile createProfile(Member member, String nickname, String introduction, boolean gender,
+		boolean registration, String nation) {
 		Profile profile = new Profile();
+		profile.member = member;
 		profile.nickname = nickname;
 		profile.introduction = introduction;
 		profile.gender = gender;
 		profile.registration = registration;
-
+		profile.nation = nation;
 		return profile;
 	}
 

--- a/wingle/src/main/java/kr/co/wingle/profile/ProfileRepository.java
+++ b/wingle/src/main/java/kr/co/wingle/profile/ProfileRepository.java
@@ -1,0 +1,12 @@
+package kr.co.wingle.profile;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import kr.co.wingle.member.entity.Member;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+	@Query("select p from Profile p where p.member = :member")
+	String findNationByMember(@Param("member") Member member);
+}

--- a/wingle/src/test/java/kr/co/wingle/member/MemberControllerTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/MemberControllerTest.java
@@ -1,0 +1,79 @@
+package kr.co.wingle.member;
+
+import static kr.co.wingle.member.MemberTemplate.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.co.wingle.common.constants.SuccessCode;
+import kr.co.wingle.common.dto.ApiResponse;
+import kr.co.wingle.member.dto.WaitingListResponseDto;
+import kr.co.wingle.member.entity.Member;
+import kr.co.wingle.member.service.AuthService;
+import kr.co.wingle.member.service.MemberService;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@WithMockUser(value = EMAIL, password = PASSWORD)
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+	private MockMvc mockMvc;
+
+	@MockBean
+	private MemberService memberService;
+
+	@MockBean
+	private AuthService authService;
+
+	ObjectMapper mapper = new ObjectMapper();
+
+	@BeforeEach
+	public void setup(WebApplicationContext webApplicationContext) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+			.addFilters(new CharacterEncodingFilter("UTF-8", true))
+			.alwaysDo(print())
+			.build();
+	}
+
+	@Test
+	void 수락_대기_목록_조회() throws Exception {
+		Member adminMember = makeTestAdminMember();
+		given(authService.findMember())
+			.willReturn(adminMember);
+		List<WaitingListResponseDto> response = new ArrayList<>();
+		given(memberService.getWaitingList(anyInt()))
+			.willReturn(response);
+
+		MockHttpServletRequestBuilder builder = get("/api/v1/admin/list/waiting/0")
+			.contentType(MediaType.APPLICATION_JSON);
+
+		mockMvc.perform(builder)
+			.andExpect(status().isOk())
+			.andExpect(content().string(
+				mapper.writeValueAsString(ApiResponse.success(SuccessCode.WAITING_LIST_READ_SUCCESS, response))
+			))
+			.andDo(print());
+	}
+}

--- a/wingle/src/test/java/kr/co/wingle/member/MemberTemplate.java
+++ b/wingle/src/test/java/kr/co/wingle/member/MemberTemplate.java
@@ -11,7 +11,9 @@ import kr.co.wingle.member.entity.Member;
 
 public class MemberTemplate {
 	public static final String EMAIL = "wingle@example.com";
-	public static final String ANOTHER_EMAIL = "mingle@example.com";
+	public static final String EMAIL2 = "wingle2@example.com";
+	public static final String EMAIL3 = "wingle3@example.com";
+	public static final String EMAIL4 = "wingle4@example.com";
 	public static final String PASSWORD = "Wingle1234!$";
 	public static final String NAME = "윙글";
 	public static final String NICKNAME = "nickname";
@@ -27,8 +29,18 @@ public class MemberTemplate {
 	}
 
 	public static Member makeTestMember2() {
-		return Member.createMember(NAME, "imageUrl", ANOTHER_EMAIL, bCryptPasswordEncoder.encode(PASSWORD),
+		return Member.createMember(NAME, "imageUrl", EMAIL2, bCryptPasswordEncoder.encode(PASSWORD),
 			Authority.ROLE_USER);
+	}
+
+	public static Member makeTestMember3() {
+		return Member.createMember(NAME, "imageUrl", EMAIL3, bCryptPasswordEncoder.encode(PASSWORD),
+			Authority.ROLE_USER);
+	}
+
+	public static Member makeTestAdminMember() {
+		return Member.createMember(NAME, "imageUrl", EMAIL4, bCryptPasswordEncoder.encode(PASSWORD),
+			Authority.ROLE_ADMIN);
 	}
 
 	public static SignupRequestDto makeTestSignUpRequestDto() throws Exception {

--- a/wingle/src/test/java/kr/co/wingle/member/service/MemberServiceTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/service/MemberServiceTest.java
@@ -1,0 +1,63 @@
+package kr.co.wingle.member.service;
+
+import static kr.co.wingle.member.MemberTemplate.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.wingle.member.MemberRepository;
+import kr.co.wingle.member.dto.WaitingListResponseDto;
+import kr.co.wingle.member.entity.Authority;
+import kr.co.wingle.member.entity.Member;
+import kr.co.wingle.member.entity.Permission;
+import kr.co.wingle.profile.ProfileRepository;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WithMockUser(value = EMAIL, password = PASSWORD)
+@Transactional
+class MemberServiceTest {
+	@Autowired
+	private MemberService memberService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private ProfileRepository profileRepository;
+
+	@BeforeAll
+	void cleanUp() {
+		memberRepository.deleteAll();
+	}
+
+	@Test
+	void 수락_대기_목록_조회() throws Exception {
+		//given
+		for (int i = 0; i < 17; i++) {
+			Member member = Member.createMember("name", "url", "wingle" + i + "@example.com",
+				"password", Authority.ROLE_USER);
+			memberRepository.save(member);
+			if (i == 16) {
+				member.setPermission(Permission.APPROVE.getStatus());
+			}
+		}
+
+		//when
+		List<WaitingListResponseDto> response1 = memberService.getWaitingList(0);
+		List<WaitingListResponseDto> response2 = memberService.getWaitingList(1);
+
+		//then
+		assertThat(response1).hasSize(15);
+		assertThat(response2).hasSize(1);
+		assertThat(response1.get(0).getCreatedTime()).isAfter(response1.get(1).getCreatedTime());
+	}
+}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 테스트 코드가 잘 통과되나요?
- [x] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [x] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 수락 대기 목록 조회 API 구현했습니다.
- 페이징 처리해서 한 번 요청당 15개씩 보내도록 했고, 최신 가입순으로 정렬해서 보냅니다.
- API 문서도 변경했으니 참고해주세요
- 포스트맨 테스트 결과
  <img width="759" alt="image" src="https://user-images.githubusercontent.com/73515587/219714556-51341856-97dc-4c3f-88de-c4fae1efec30.png">

resolved: #53 
