### PR TITLE
[feat] 회원가입 API 수정

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/member/TermMemberRepository.java
+++ b/wingle/src/main/java/kr/co/wingle/member/TermMemberRepository.java
@@ -1,0 +1,12 @@
+package kr.co.wingle.member;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.wingle.member.entity.Member;
+import kr.co.wingle.member.entity.TermMember;
+
+public interface TermMemberRepository extends JpaRepository<TermMember, Long> {
+	List<TermMember> findAllByMember(Member member);
+}

--- a/wingle/src/main/java/kr/co/wingle/member/TermRepository.java
+++ b/wingle/src/main/java/kr/co/wingle/member/TermRepository.java
@@ -1,0 +1,11 @@
+package kr.co.wingle.member;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.wingle.member.entity.Term;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+	Optional<Term> findByName(String name);
+}

--- a/wingle/src/main/java/kr/co/wingle/member/dto/LoginRequestDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/LoginRequestDto.java
@@ -1,5 +1,6 @@
 package kr.co.wingle.member.dto;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginRequestDto {
+	@Email
 	@NotBlank(message = "이메일이 없습니다.")
 	private String email;
 

--- a/wingle/src/main/java/kr/co/wingle/member/dto/SignupRequestDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/SignupRequestDto.java
@@ -1,6 +1,7 @@
 package kr.co.wingle.member.dto;
 
 import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
@@ -21,6 +22,7 @@ public class SignupRequestDto {
 	@NotNull(message = "파일이 없습니다.")
 	private MultipartFile idCardImage;
 
+	@Email
 	@NotBlank(message = "이메일이 없습니다.")
 	private String email;
 
@@ -29,6 +31,9 @@ public class SignupRequestDto {
 
 	@NotBlank(message = "이름이 없습니다.")
 	private String name;
+
+	@AssertTrue(message = "닉네임 중복 검사를 통과해야 합니다.")
+	private boolean isNicknameChecked;
 
 	@NotBlank(message = "닉네임이 없습니다.")
 	private String nickname;
@@ -43,7 +48,10 @@ public class SignupRequestDto {
 	private boolean termsOfUse;
 
 	@AssertTrue(message = "약관에 필수로 동의해야 합니다.")
-	private boolean collectionOfPersonalInformation;
+	private boolean termsOfPersonalInformation;
+
+	@NotNull
+	private boolean termsOfPromotion;
 
 	public Member toMember(String idCardImageUrl, PasswordEncoder passwordEncoder) {
 		return Member.createMember(name, idCardImageUrl, email, passwordEncoder.encode(password), Authority.ROLE_USER);

--- a/wingle/src/main/java/kr/co/wingle/member/entity/Term.java
+++ b/wingle/src/main/java/kr/co/wingle/member/entity/Term.java
@@ -8,9 +8,9 @@ import org.hibernate.annotations.ColumnDefault;
 
 import kr.co.wingle.common.entity.BaseEntity;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "term")
@@ -19,7 +19,8 @@ import lombok.NoArgsConstructor;
 public class Term extends BaseEntity {
 
 	@Column(nullable = false)
-	private int code;
+	@Setter
+	private Long code;
 
 	@Column(nullable = false)
 	private String name;
@@ -27,4 +28,12 @@ public class Term extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "TINYINT", length = 1)
 	@ColumnDefault("1")
 	private boolean necessity = true;
+
+	public static Term createTerm(long code, String name, boolean necessity) {
+		Term term = new Term();
+		term.code = code;
+		term.name = name;
+		term.necessity = necessity;
+		return term;
+	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/entity/TermCode.java
+++ b/wingle/src/main/java/kr/co/wingle/member/entity/TermCode.java
@@ -1,0 +1,16 @@
+package kr.co.wingle.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TermCode {
+	TERMS_OF_USE("서비스 이용약관", true, 0L),
+	TERMS_OF_PERSONAL_INFORMATION("개인정보 수집 및 이용 동의", true, 0L),
+	TERMS_OF_PROMOTION("이벤트, 프로모션 알림 메일 수신", false, 0L);
+
+	private final String name;
+	private final boolean necessity;
+	private final Long code; //부모코드
+}

--- a/wingle/src/main/java/kr/co/wingle/member/entity/TermMember.java
+++ b/wingle/src/main/java/kr/co/wingle/member/entity/TermMember.java
@@ -31,4 +31,12 @@ public class TermMember extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "TINYINT", length = 1)
 	@ColumnDefault("0")
 	private boolean agreement = false;
+
+	public static TermMember createTermMember(Term term, Member member, boolean agreement) {
+		TermMember termMember = new TermMember();
+		termMember.term = term;
+		termMember.member = member;
+		termMember.agreement = agreement;
+		return termMember;
+	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
@@ -21,6 +21,7 @@ import kr.co.wingle.common.util.RedisUtil;
 import kr.co.wingle.common.util.S3Util;
 import kr.co.wingle.common.util.SecurityUtil;
 import kr.co.wingle.member.MemberRepository;
+import kr.co.wingle.member.entity.TermCode;
 import kr.co.wingle.member.TermMemberRepository;
 import kr.co.wingle.member.TermRepository;
 import kr.co.wingle.member.dto.CertificationRequestDto;
@@ -67,12 +68,10 @@ public class AuthService {
 		memberRepository.save(member);
 
 		// save termMember
-		final String TERMS_OF_USE = "서비스 이용약관";
-		final String TERMS_OF_PERSONAL_INFORMATION = "개인정보 수집 및 이용 동의";
-		final String TERMS_OF_PROMOTION = "이벤트, 프로모션 알림 메일 수신";
-		getTermAndSaveTermMember(member, TERMS_OF_USE, request.isTermsOfUse(), true);
-		getTermAndSaveTermMember(member, TERMS_OF_PERSONAL_INFORMATION, request.isTermsOfPersonalInformation(), true);
-		getTermAndSaveTermMember(member, TERMS_OF_PROMOTION, request.isTermsOfPromotion(), false);
+		getTermAndSaveTermMember(member, TermCode.TERMS_OF_USE, request.isTermsOfUse());
+		getTermAndSaveTermMember(member, TermCode.TERMS_OF_PERSONAL_INFORMATION,
+			request.isTermsOfPersonalInformation());
+		getTermAndSaveTermMember(member, TermCode.TERMS_OF_PROMOTION, request.isTermsOfPromotion());
 
 		// save profile
 		Profile profile = Profile.createProfile(member, request.getNickname(), request.isGender(), request.getNation());
@@ -146,10 +145,10 @@ public class AuthService {
 		return CertificationResponseDto.of(true);
 	}
 
-	private void getTermAndSaveTermMember(Member member, String termName, boolean agreement, boolean termNecessity) {
-		Optional<Term> termOptional = termRepository.findByName(termName);
+	private void getTermAndSaveTermMember(Member member, TermCode termCode, boolean agreement) {
+		Optional<Term> termOptional = termRepository.findByName(termCode.getName());
 		if (termOptional.isEmpty()) {
-			Term term = Term.createTerm(0, termName, termNecessity);
+			Term term = Term.createTerm(termCode.getCode(), termCode.getName(), termCode.isNecessity());
 			termRepository.save(term);
 			TermMember termMember = TermMember.createTermMember(term, member, agreement);
 			termMemberRepository.save(termMember);

--- a/wingle/src/main/java/kr/co/wingle/member/service/MemberService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/MemberService.java
@@ -8,8 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.wingle.member.MemberRepository;
 import kr.co.wingle.member.dto.WaitingListResponseDto;
-import kr.co.wingle.member.entity.Permiss
-ion;
+import kr.co.wingle.member.entity.Permission;
 import kr.co.wingle.profile.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 

--- a/wingle/src/main/java/kr/co/wingle/member/service/MemberService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/MemberService.java
@@ -6,15 +6,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import kr.co.wingle.common.constants.ErrorCode;
-import kr.co.wingle.common.exception.CustomException;
-import kr.co.wingle.common.exception.ForbiddenException;
-import kr.co.wingle.common.exception.NotFoundException;
 import kr.co.wingle.member.MemberRepository;
 import kr.co.wingle.member.dto.WaitingListResponseDto;
-import kr.co.wingle.member.entity.Authority;
-import kr.co.wingle.member.entity.Member;
-import kr.co.wingle.member.entity.Permission;
+import kr.co.wingle.member.entity.Permiss
+ion;
 import kr.co.wingle.profile.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 

--- a/wingle/src/main/java/kr/co/wingle/profile/Profile.java
+++ b/wingle/src/main/java/kr/co/wingle/profile/Profile.java
@@ -30,6 +30,7 @@ public class Profile extends BaseEntity {
 	private String nickname;
 
 	@Column(columnDefinition = "TEXT")
+	@Setter
 	private String introduction;
 
 	@Column(nullable = false)
@@ -43,14 +44,13 @@ public class Profile extends BaseEntity {
 	@Column(nullable = false)
 	private String nation;
 
-	public static Profile createProfile(Member member, String nickname, String introduction, boolean gender,
-		boolean registration, String nation) {
+	public static Profile createProfile(Member member, String nickname, boolean gender, String nation) {
 		Profile profile = new Profile();
 		profile.member = member;
 		profile.nickname = nickname;
-		profile.introduction = introduction;
+		profile.introduction = null;
 		profile.gender = gender;
-		profile.registration = registration;
+		profile.registration = false;
 		profile.nation = nation;
 		return profile;
 	}

--- a/wingle/src/main/java/kr/co/wingle/profile/ProfileRepository.java
+++ b/wingle/src/main/java/kr/co/wingle/profile/ProfileRepository.java
@@ -1,5 +1,7 @@
 package kr.co.wingle.profile;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,4 +11,6 @@ import kr.co.wingle.member.entity.Member;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 	@Query("select p from Profile p where p.member = :member")
 	String findNationByMember(@Param("member") Member member);
+
+	Optional<Profile> findByMember(Member member);
 }

--- a/wingle/src/main/java/kr/co/wingle/profile/ProfileRepository.java
+++ b/wingle/src/main/java/kr/co/wingle/profile/ProfileRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import kr.co.wingle.member.entity.Member;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
-	@Query("select p from Profile p where p.member = :member")
+	@Query("select p.nation from Profile p where p.member = :member")
 	String findNationByMember(@Param("member") Member member);
 
 	Optional<Profile> findByMember(Member member);

--- a/wingle/src/test/java/kr/co/wingle/member/AuthControllerTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/AuthControllerTest.java
@@ -69,11 +69,13 @@ class AuthControllerTest {
 			.param("email", requestDto.getEmail())
 			.param("password", requestDto.getPassword())
 			.param("name", requestDto.getName())
+			.param("isNicknameChecked", String.valueOf(requestDto.isNicknameChecked()))
 			.param("nickname", requestDto.getNickname())
 			.param("gender", String.valueOf(requestDto.isGender()))
 			.param("nation", requestDto.getNation())
 			.param("termsOfUse", String.valueOf(requestDto.isTermsOfUse()))
-			.param("collectionOfPersonalInformation", String.valueOf(requestDto.isCollectionOfPersonalInformation()))
+			.param("termsOfPersonalInformation", String.valueOf(requestDto.isTermsOfPersonalInformation()))
+			.param("termsOfPromotion", String.valueOf(requestDto.isTermsOfPromotion()))
 			.contentType(MediaType.MULTIPART_FORM_DATA);
 
 		mockMvc.perform(builder)

--- a/wingle/src/test/java/kr/co/wingle/member/MemberTemplate.java
+++ b/wingle/src/test/java/kr/co/wingle/member/MemberTemplate.java
@@ -43,7 +43,8 @@ public class MemberTemplate {
 	}
 
 	public static SignupRequestDto makeTestSignUpRequestDto() throws Exception {
-		return new SignupRequestDto(getTestIdCardImage(), EMAIL, PASSWORD, NAME, NICKNAME, GENDER, NATION, true, true);
+		return new SignupRequestDto(getTestIdCardImage(), EMAIL, PASSWORD, NAME, true, NICKNAME, GENDER, NATION, true,
+			true, false);
 	}
 
 	public static MockMultipartFile getTestIdCardImage() throws Exception {

--- a/wingle/src/test/java/kr/co/wingle/member/service/AuthServiceTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/service/AuthServiceTest.java
@@ -3,19 +3,23 @@ package kr.co.wingle.member.service;
 import static kr.co.wingle.member.MemberTemplate.*;
 import static org.assertj.core.api.Assertions.*;
 
-import org.junit.jupiter.api.AfterEach;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.wingle.common.constants.ErrorCode;
 import kr.co.wingle.common.exception.DuplicateException;
 import kr.co.wingle.common.exception.NotFoundException;
 import kr.co.wingle.common.util.RedisUtil;
+import kr.co.wingle.common.util.S3Util;
 import kr.co.wingle.member.MemberRepository;
+import kr.co.wingle.member.TermMemberRepository;
 import kr.co.wingle.member.dto.LoginRequestDto;
 import kr.co.wingle.member.dto.LogoutRequestDto;
 import kr.co.wingle.member.dto.SignupRequestDto;
@@ -23,10 +27,14 @@ import kr.co.wingle.member.dto.SignupResponseDto;
 import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.member.dto.TokenRequestDto;
 import kr.co.wingle.member.entity.Member;
+import kr.co.wingle.member.entity.TermMember;
+import kr.co.wingle.profile.Profile;
+import kr.co.wingle.profile.ProfileRepository;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @WithMockUser(value = EMAIL, password = PASSWORD)
+@Transactional
 class AuthServiceTest {
 	@Autowired
 	private AuthService authService;
@@ -35,10 +43,18 @@ class AuthServiceTest {
 	private MemberRepository memberRepository;
 
 	@Autowired
+	private ProfileRepository profileRepository;
+
+	@Autowired
+	private TermMemberRepository termMemberRepository;
+
+	@Autowired
 	private RedisUtil redisUtil;
 
+	@Autowired
+	private S3Util s3Util;
+
 	@BeforeAll
-	@AfterEach
 	void cleanUp() {
 		memberRepository.deleteAll();
 	}
@@ -52,9 +68,19 @@ class AuthServiceTest {
 		SignupResponseDto response = authService.signup(requestDto);
 		Member member = memberRepository.findById(response.getId())
 			.orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_ID.getMessage()));
+		Profile profile = profileRepository.findByMember(member)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.DATA_NOT_FOUND));
+		List<TermMember> termMemberList = termMemberRepository.findAllByMember(member);
 
 		//then
 		assertThat(member.getEmail()).isEqualTo(requestDto.getEmail());
+		assertThat(profile.getNickname()).isEqualTo(requestDto.getNickname());
+		assertThat(profile.getNation()).isEqualTo(requestDto.getNation());
+		assertThat(profile.isGender()).isEqualTo(requestDto.isGender());
+		assertThat(termMemberList).hasSize(3);
+
+		//teardown
+		s3Util.delete(member.getIdCardImageUrl());
 	}
 
 	@Test
@@ -204,9 +230,9 @@ class AuthServiceTest {
 
 		//teardown
 		redisUtil.deleteData(RedisUtil.PREFIX_LOGOUT + requestDto.getAccessToken());
-  }
-  
-  @Test
+	}
+
+	@Test
 	void 이메일로_인증번호_전송_성공() {
 	}
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 테스트 코드가 잘 통과되나요?
- [x] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [x] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 회원가입 서비스코드에서 termMember 저장하고, profile 저장하는 부분 추가했습니다. 맞춰서 테스트코드도 변경했습니다.
- 약관의 경우, 약관 테이블에 해당 약관이 있는지 검사하고 없으면 약관을 저장한 후 termMember를 저장하도록 했습니다.
- 기존에 있던 이메일 형식 검사하는 validateEmail() 메서드를 빼고 요청 DTO에 Email 어노테이션을 붙이는 방법으로 바꿨습니다.
- public 메서드들 아래에 private 메서드들이 있는게 보기 좋을 것 같아서 메일 관련 메서드 2개를 위로 올렸습니다.
- 약관 테이블의 code를 int에서 Long으로 변경했습니다.

resolved: #46 
