### PR TITLE
[Breaking change] 로그인 API 수정

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/member/dto/TokenDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/TokenDto.java
@@ -14,6 +14,9 @@ public class TokenDto {
 	@Setter
 	private String refreshToken;
 
+	@Setter
+	private boolean isAdmin;
+
 	public static TokenDto of(String accessToken, String refreshToken) {
 		TokenDto tokenDto = new TokenDto();
 		tokenDto.accessToken = accessToken;

--- a/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
@@ -32,6 +32,7 @@ import kr.co.wingle.member.dto.SignupRequestDto;
 import kr.co.wingle.member.dto.SignupResponseDto;
 import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.member.dto.TokenRequestDto;
+import kr.co.wingle.member.entity.Authority;
 import kr.co.wingle.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 
@@ -70,12 +71,14 @@ public class AuthService {
 	public TokenDto login(LoginRequestDto loginRequestDto) {
 		String email = loginRequestDto.getEmail();
 		validateEmail(email);
-		memberRepository.findByEmail(email)
+		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
 		UsernamePasswordAuthenticationToken authenticationToken = loginRequestDto.toAuthentication();
 		Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-		return getRedisTokenKey(authentication);
+		TokenDto tokenDto = getRedisTokenKey(authentication);
+		tokenDto.setAdmin(member.getAuthority() == Authority.ROLE_ADMIN);
+		return tokenDto;
 	}
 
 	@Transactional(readOnly = true)

--- a/wingle/src/test/java/kr/co/wingle/member/service/AuthServiceTest.java
+++ b/wingle/src/test/java/kr/co/wingle/member/service/AuthServiceTest.java
@@ -96,11 +96,11 @@ class AuthServiceTest {
 	}
 
 	@Test
-	void 로그인() throws Exception {
+	void 일반유저_로그인() throws Exception {
 		//given
 		Member member = makeTestMember();
 		memberRepository.save(member);
-		LoginRequestDto requestDto = LoginRequestDto.of(EMAIL, PASSWORD);
+		LoginRequestDto requestDto = LoginRequestDto.of(member.getEmail(), PASSWORD);
 
 		//when
 		TokenDto response = authService.login(requestDto);
@@ -112,6 +112,30 @@ class AuthServiceTest {
 		assertThat(response.getAccessToken()).isNotNull();
 		assertThat(response.getRefreshToken()).isNotNull();
 		assertThat(refreshToken).isNotNull();
+		assertThat(response.isAdmin()).isFalse();
+
+		//teardown
+		redisUtil.deleteData(key);
+	}
+
+	@Test
+	void 관리자_로그인() throws Exception {
+		//given
+		Member member = makeTestAdminMember();
+		memberRepository.save(member);
+		LoginRequestDto requestDto = LoginRequestDto.of(member.getEmail(), PASSWORD);
+
+		//when
+		TokenDto response = authService.login(requestDto);
+
+		//then
+		String key = RedisUtil.PREFIX_REFRESH_TOKEN + response.getRefreshToken();
+		String refreshToken = redisUtil.getData(key);
+
+		assertThat(response.getAccessToken()).isNotNull();
+		assertThat(response.getRefreshToken()).isNotNull();
+		assertThat(refreshToken).isNotNull();
+		assertThat(response.isAdmin()).isTrue();
 
 		//teardown
 		redisUtil.deleteData(key);
@@ -204,9 +228,9 @@ class AuthServiceTest {
 
 		//teardown
 		redisUtil.deleteData(RedisUtil.PREFIX_LOGOUT + requestDto.getAccessToken());
-  }
-  
-  @Test
+	}
+
+	@Test
 	void 이메일로_인증번호_전송_성공() {
 	}
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 테스트 코드가 잘 통과되나요?
- [x] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [ ] Feature
- [x] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 로그인 후 관리자 계정인지 여부를 응답에 보내주도록 수정했습니다.
- 관리자 계정일 경우
    <img width="768" alt="스크린샷 2023-02-19 오후 1 50 25" src="https://user-images.githubusercontent.com/73515587/219923140-768a7655-6d38-4d35-a6e2-83d99d1006ba.png">
- 일반 유저일 경우
    <img width="768" alt="스크린샷 2023-02-19 오후 1 52 30" src="https://user-images.githubusercontent.com/73515587/219923150-f7d979ba-b82f-47cb-84c4-840bed42c71b.png">


resolved: #58 
