### PR TITLE
[feat] 이미 가입 승인한 유저는 거절하지 못하도록 수정 #65

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
@@ -1,5 +1,3 @@
-
-
 package kr.co.wingle.member.service;
 
 import java.util.Optional;
@@ -23,7 +21,6 @@ import kr.co.wingle.common.util.RedisUtil;
 import kr.co.wingle.common.util.S3Util;
 import kr.co.wingle.common.util.SecurityUtil;
 import kr.co.wingle.member.MemberRepository;
-import kr.co.wingle.member.entity.TermCode;
 import kr.co.wingle.member.TermMemberRepository;
 import kr.co.wingle.member.TermRepository;
 import kr.co.wingle.member.dto.AcceptanceRequestDto;
@@ -40,14 +37,15 @@ import kr.co.wingle.member.dto.SignupResponseDto;
 import kr.co.wingle.member.dto.TokenDto;
 import kr.co.wingle.member.dto.TokenRequestDto;
 import kr.co.wingle.member.entity.Member;
-import kr.co.wingle.member.entity.Term;
-import kr.co.wingle.member.entity.TermMember;
-import kr.co.wingle.profile.Profile;
-import kr.co.wingle.profile.ProfileRepository;
 import kr.co.wingle.member.entity.Permission;
+import kr.co.wingle.member.entity.Term;
+import kr.co.wingle.member.entity.TermCode;
+import kr.co.wingle.member.entity.TermMember;
 import kr.co.wingle.member.mailVo.AcceptanceMail;
 import kr.co.wingle.member.mailVo.CodeMail;
 import kr.co.wingle.member.mailVo.RejectionMail;
+import kr.co.wingle.profile.Profile;
+import kr.co.wingle.profile.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -172,6 +170,8 @@ public class AuthService {
 		Member member = validateMember(userId);
 		if (member.getPermission() == Permission.DENY.getStatus())
 			throw new CustomException(ErrorCode.ALREADY_DENY);
+		if (member.getPermission() == Permission.APPROVE.getStatus())
+			throw new CustomException(ErrorCode.ALREADY_ACCEPTANCE);
 
 		member.setPermission(Permission.DENY.getStatus());
 		// TODO: 거절 사유 저장


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [x] 이 프로젝트의 코드 스타일을 따르나요?
- [x] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [x] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 어드민이 이미 수락했던 회원은 거절할 수 없도록 기능을 수정합니다.
- 따라서 거절 전송 시 이미 수락했던 회원인지 확인하고, 수락했었다면 "이미 가입 승인된 유저입니다."로 응답합니다.

## 💻 실행결과
- postman
- 이미 승인된 회원에게 거절 전송 버튼을 누른 경우
![image](https://user-images.githubusercontent.com/56223389/219935711-3568118e-dab9-494e-a33c-7f325ade152a.png)

resolved: #65
