### PR TITLE
[fix] 프로필 상세조회 image 수정

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/profile/ProfileService.java
+++ b/wingle/src/main/java/kr/co/wingle/profile/ProfileService.java
@@ -143,8 +143,8 @@ public class ProfileService {
 				ErrorCode.NO_PROFILE));
 	}
 
-	private String uploadProfileImage(MultipartFile idCardImage) {
-		return s3Util.profileImageUpload(idCardImage);
+	private String uploadProfileImage(MultipartFile profileImage) {
+		return s3Util.profileImageUpload(profileImage);
 	}
 
 	private void setRegistration(Member member) {
@@ -179,7 +179,7 @@ public class ProfileService {
 	public ProfileViewResponseDto getProfileDetail() {
 		Member member = authService.findMember();
 		Profile profile = getProfile(member);
-		String image = member.getIdCardImageUrl();
+		String image = profile.getImageUrl();
 		String nation = profile.getNation();
 		String nickname = profile.getNickname();
 		Boolean gender = profile.isGender();


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [ ] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [ ] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 프로필 상세조회에서 Reponse의 image가 프로필이미지가 아닌 idCard 이미지로 들어가 있었음
- idCardImage->profileImage로 수정
- uploadProfileImage 함수에서 매개변수 이름이 idCardImage로 되어있길래 헷갈려서 profileImage로 바꿈

resolved: #131 
