### PR TITLE
[add] 게시글 res 국적 추가 #137

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/community/article/ArticleMapper.java
+++ b/wingle/src/main/java/kr/co/wingle/community/article/ArticleMapper.java
@@ -39,6 +39,7 @@ public class ArticleMapper {
 		articleResponseDto.isMine(processedPersonalInformation.isMine());
 		articleResponseDto.userId(processedPersonalInformation.getProcessedMemberId());
 		articleResponseDto.userImage(profileService.getProfileByMemberId(article.getMember().getId()).getImageUrl());
+		articleResponseDto.userNation(profileService.getProfileByMemberId(article.getMember().getId()).getNation());
 		articleResponseDto.forumId(article.getForum().getId());
 
 		return articleResponseDto.build();

--- a/wingle/src/main/java/kr/co/wingle/community/article/ArticleResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/community/article/ArticleResponseDto.java
@@ -19,6 +19,7 @@ public class ArticleResponseDto {
 	private Long userId;
 	private String userNickname;
 	private String userImage;
+	private String userNation;
 	private LocalDateTime createdTime;
 	private LocalDateTime updatedTime;
 	private Long forumId;

--- a/wingle/src/main/java/kr/co/wingle/community/forum/ForumService.java
+++ b/wingle/src/main/java/kr/co/wingle/community/forum/ForumService.java
@@ -31,7 +31,7 @@ public class ForumService {
 	}
 
 	static public String getNicknameByForum(Forum forum, Profile profile) {
-		final String nationCodeKor = "kor";
+		final String nationCodeKor = "KR";
 		final String anonymousKor = "한국 윙그리";
 		final String anonymousNoneKor = "외국 윙그리";
 		final String admin = "관리자";


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [ ] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [ ] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 게시글 response body에 국적(nation) 추가했습니다.
- 익명 게시판에서 닉네임을 국적에 따라 한국윙그리 or 외국윙그리로 반환하는데, 여기서 비교값인 nationCodeKor 변수값을 'KR'로 수정했습니다. (프론트에서 백으로 국적을 보내줄 때 국가코드로 보내주기로 결정했기 때문에)

resolved: #137
