### PR TITLE
[fix] 쪽지 createdTime 비교 로직 수정 #142

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/message/dto/RoomResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/message/dto/RoomResponseDto.java
@@ -40,7 +40,7 @@ public class RoomResponseDto implements Comparable<RoomResponseDto> {
 	@Override
 	public int compareTo(RoomResponseDto response) {
 		// createdTime이 없으면 정렬하지 않음
-		if (this.getCreatedTime() == null)
+		if (this.getCreatedTime() == null || response.getCreatedTime() == null)
 			return 0;
 		if (response.getCreatedTime().isAfter(this.getCreatedTime())) {
 			return 1;


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [x] 이 프로젝트의 코드 스타일을 따르나요?
- [x] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [x] Bug
- [ ] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 쪽지방 리스트 찾기 시 쪽지방에 쪽지가 하나만 있는 경우 에러 발생
- 원인은 쪽지 createdTime 비교 시 null 값이 들어와서
- 쪽지 createdTime 비교 로직 수정

resolved: #142
