### PR TITLE
[feature] recipient 프로필 이미지 추가, 내 자신의 닉네임 null처리 #144

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/message/controller/MessageController.java
+++ b/wingle/src/main/java/kr/co/wingle/message/controller/MessageController.java
@@ -1,7 +1,5 @@
 package kr.co.wingle.message.controller;
 
-import java.util.List;
-
 import javax.validation.Valid;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +15,7 @@ import kr.co.wingle.common.dto.ApiResponse;
 import kr.co.wingle.common.util.StringUtil;
 import kr.co.wingle.message.dto.MessageRequestDto;
 import kr.co.wingle.message.dto.MessageResponseDto;
+import kr.co.wingle.message.dto.MessageResponseWithRecipentDto;
 import kr.co.wingle.message.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +34,7 @@ public class MessageController {
 	}
 
 	@GetMapping("/{roomId}")
-	public ApiResponse<List<MessageResponseDto>> getList(@PathVariable String roomId,
+	public ApiResponse<MessageResponseWithRecipentDto> getList(@PathVariable String roomId,
 		@RequestParam String page, @RequestParam String size) {
 		return ApiResponse.success(SuccessCode.GET_SUCCESS,
 			messageService.getListByRoom(StringUtil.StringToLong(roomId),

--- a/wingle/src/main/java/kr/co/wingle/message/dto/MessageResponseWithRecipentDto.java
+++ b/wingle/src/main/java/kr/co/wingle/message/dto/MessageResponseWithRecipentDto.java
@@ -1,0 +1,28 @@
+package kr.co.wingle.message.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MessageResponseWithRecipentDto {
+	private String recipientImage;
+
+	private List<MessageResponseDto> messages;
+
+	public static MessageResponseWithRecipentDto of() {
+		return MessageResponseWithRecipentDto.builder()
+			.recipientImage(null)
+			.messages(null)
+			.build();
+	}
+
+	public static MessageResponseWithRecipentDto of(String recipientImage, List<MessageResponseDto> messages) {
+		return MessageResponseWithRecipentDto.builder()
+			.recipientImage(recipientImage)
+			.messages(messages)
+			.build();
+	}
+}

--- a/wingle/src/main/java/kr/co/wingle/message/mapper/MessageMapper.java
+++ b/wingle/src/main/java/kr/co/wingle/message/mapper/MessageMapper.java
@@ -1,7 +1,11 @@
 package kr.co.wingle.message.mapper;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Component;
 
+import kr.co.wingle.member.entity.Member;
+import kr.co.wingle.member.service.AuthService;
 import kr.co.wingle.message.dto.MessageResponseDto;
 import kr.co.wingle.message.entity.Message;
 import kr.co.wingle.profile.ProfileService;
@@ -15,10 +19,18 @@ public class MessageMapper {
 	private final ProfileService profileService;
 	private final WritingUtil writingUtil;
 
+	private final AuthService authService;
+
 	public MessageResponseDto toResponseDto(Message message) {
 		boolean isMine = writingUtil.isMine(message);
+		Member member = authService.findAcceptedLoggedInMember();
+
 		Profile profile = profileService.getProfileByMemberId(message.getMember().getId());
-		return MessageResponseDto.of(message.getId(), profile.getNickname(), message.getContent(),
+
+		// 메세지 송신자가 나 자신일 경우 닉네임 대신 null 반환
+		return MessageResponseDto.of(message.getId(),
+			!Objects.equals(profile.getMember().getId(), member.getId()) ? profile.getNickname() : null,
+			message.getContent(),
 			message.getCreatedTime(), isMine);
 	}
 }


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [ ] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [ ] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 대화 상대방의 프로필 이미지를 반환
- 메세지 아이템의 닉네임은 나 자신일 경우 null 처리하여 전달하지 않음

resolved: #144 
