### PR TITLE
[Refactor] admin userId 암호화 #161

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/common/util/AES256Util.java
+++ b/wingle/src/main/java/kr/co/wingle/common/util/AES256Util.java
@@ -8,7 +8,6 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.codec.binary.Base64;
 import org.springframework.stereotype.Component;
 
 import kr.co.wingle.common.constants.ErrorCode;
@@ -17,11 +16,11 @@ import kr.co.wingle.common.exception.CustomException;
 @Component
 public class AES256Util {
 	//initial vector 설정
-	private String iv = "0000000000000001";
-	private Key keySpec;
+	private static String iv = "0000000000000001";
+	private static Key keySpec;
 
 	public AES256Util() throws UnsupportedEncodingException {
-		this.iv = iv.substring(0, 16);
+		iv = iv.substring(0, 16);
 		byte[] keyBytes = new byte[16];
 		byte[] b = iv.getBytes("UTF-8");
 		int len = b.length;
@@ -29,29 +28,30 @@ public class AES256Util {
 			len = keyBytes.length;
 		}
 		System.arraycopy(b, 0, keyBytes, 0, len);
-		SecretKeySpec keySpec = new SecretKeySpec(keyBytes, "AES");
-		this.keySpec = keySpec;
+		SecretKeySpec _keySpec = new SecretKeySpec(keyBytes, "AES");
+		keySpec = _keySpec;
 	}
 
 	//암호화
-	public String encrypt(String str) {
+	public static String encrypt(String str) {
 		try {
 			Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
 			c.init(Cipher.ENCRYPT_MODE, keySpec, new IvParameterSpec((iv.getBytes())));
 			byte[] encrypted = c.doFinal(str.getBytes("UTF-8"));
-			String enStr = new String(Base64.encodeBase64(encrypted));
-			return enStr;
+			// String enStr = new String(Base64.encodeBase64(encrypted));
+			return new java.math.BigInteger(encrypted).toString(16);
 		} catch (GeneralSecurityException | UnsupportedEncodingException e) {
 			throw new CustomException(ErrorCode.ENCRYPT_FAIL);
 		}
 	}
 
 	//복호화
-	public String decrypt(String str) {
+	public static String decrypt(String str) {
 		try {
 			Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
 			c.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(iv.getBytes()));
-			byte[] byteStr = Base64.decodeBase64(str.getBytes());
+			// byte[] byteStr = Base64.decodeBase64(str.getBytes());
+			byte[] byteStr = new java.math.BigInteger(str, 16).toByteArray();
 			return new String(c.doFinal(byteStr), "UTF-8");
 		} catch (GeneralSecurityException | UnsupportedEncodingException e) {
 			throw new CustomException(ErrorCode.DECRYPT_FAIL);

--- a/wingle/src/main/java/kr/co/wingle/member/MemberController.java
+++ b/wingle/src/main/java/kr/co/wingle/member/MemberController.java
@@ -15,6 +15,7 @@ import kr.co.wingle.common.constants.ErrorCode;
 import kr.co.wingle.common.constants.SuccessCode;
 import kr.co.wingle.common.dto.ApiResponse;
 import kr.co.wingle.common.exception.ForbiddenException;
+import kr.co.wingle.common.util.AES256Util;
 import kr.co.wingle.member.dto.AcceptanceRequestDto;
 import kr.co.wingle.member.dto.MemoRequestDto;
 import kr.co.wingle.member.dto.MemoResponseDto;
@@ -50,9 +51,12 @@ public class MemberController {
 	}
 
 	@GetMapping("/waiting/{userId}")
-	public ApiResponse<WaitingUserResponseDto> waitingUser(@PathVariable Long userId) {
+	public ApiResponse<WaitingUserResponseDto> waitingUser(@PathVariable String userId) {
 		checkAdminAccount();
-		WaitingUserResponseDto response = memberService.getWaitingUserInfo(userId);
+
+		Long userId_long = Long.parseLong(AES256Util.decrypt(userId));
+
+		WaitingUserResponseDto response = memberService.getWaitingUserInfo(userId_long);
 		return ApiResponse.success(SuccessCode.WAITING_USER_READ_SUCCESS, response);
 	}
 

--- a/wingle/src/main/java/kr/co/wingle/member/dto/PermissionResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/PermissionResponseDto.java
@@ -2,6 +2,7 @@ package kr.co.wingle.member.dto;
 
 import javax.validation.constraints.NotBlank;
 
+import kr.co.wingle.common.util.AES256Util;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,13 +11,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PermissionResponseDto {
 	@NotBlank
-	private Long userId;
+	private String userId;
 	@NotBlank
 	private boolean permission;
 
 	public static PermissionResponseDto of(Long userId, boolean permission) {
 		PermissionResponseDto permissionResponseDto = new PermissionResponseDto();
-		permissionResponseDto.userId = userId;
+		permissionResponseDto.userId = AES256Util.encrypt(userId.toString());
 		permissionResponseDto.permission = permission;
 		return permissionResponseDto;
 	}

--- a/wingle/src/main/java/kr/co/wingle/member/dto/SignupListResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/SignupListResponseDto.java
@@ -2,6 +2,7 @@ package kr.co.wingle.member.dto;
 
 import java.time.LocalDateTime;
 
+import kr.co.wingle.common.util.AES256Util;
 import kr.co.wingle.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,14 +11,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignupListResponseDto {
-	private Long userId;
+	private String userId;
 	private LocalDateTime createdTime;
 	private String name;
 	private String nation;
 
 	public static SignupListResponseDto from(Member member, String nation) {
 		SignupListResponseDto signupListResponseDto = new SignupListResponseDto();
-		signupListResponseDto.userId = member.getId();
+		signupListResponseDto.userId = AES256Util.encrypt(member.getId().toString());
 		signupListResponseDto.createdTime = member.getCreatedTime();
 		signupListResponseDto.name = member.getName();
 		signupListResponseDto.nation = nation;

--- a/wingle/src/main/java/kr/co/wingle/member/dto/WaitingUserResponseDto.java
+++ b/wingle/src/main/java/kr/co/wingle/member/dto/WaitingUserResponseDto.java
@@ -2,6 +2,7 @@ package kr.co.wingle.member.dto;
 
 import java.time.LocalDateTime;
 
+import kr.co.wingle.common.util.AES256Util;
 import kr.co.wingle.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WaitingUserResponseDto {
-	private Long userId;
+	private String userId;
 	private String name;
 	private LocalDateTime createdTime;
 	private String idCardImage;
@@ -20,7 +21,7 @@ public class WaitingUserResponseDto {
 
 	public static WaitingUserResponseDto from(Member member, String nation) {
 		WaitingUserResponseDto waitingUserResponseDto = new WaitingUserResponseDto();
-		waitingUserResponseDto.userId = member.getId();
+		waitingUserResponseDto.userId = AES256Util.encrypt(member.getId().toString());
 		waitingUserResponseDto.name = member.getName();
 		waitingUserResponseDto.createdTime = member.getCreatedTime();
 		waitingUserResponseDto.idCardImage = member.getIdCardImageUrl();


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [ ] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [ ] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
base64로 암호화시 특수문자("\")가 섞여 query string에서 사용할 수 없는 이슈
- base64 -> hex로 변경

`AES256Util` 사용시 인스턴스 없이 사용할 수 있도록 static 추가(인스턴스를 생성해도 사용가능)

admin 조회 api에서 각 req, res의 `userId` 암호화

resolved: #161 
