### PR TITLE
[fix] CustomException http status별로 분리

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/common/exception/BadRequestException.java
+++ b/wingle/src/main/java/kr/co/wingle/common/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package kr.co.wingle.common.exception;
+
+import kr.co.wingle.common.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+	private final ErrorCode code;
+
+	public BadRequestException(ErrorCode code) {
+		super(code.getMessage());
+		this.code = code;
+	}
+}

--- a/wingle/src/main/java/kr/co/wingle/common/exception/InternalServerErrorException.java
+++ b/wingle/src/main/java/kr/co/wingle/common/exception/InternalServerErrorException.java
@@ -4,10 +4,11 @@ import kr.co.wingle.common.constants.ErrorCode;
 import lombok.Getter;
 
 @Getter
-public class CustomException extends RuntimeException {
+public class InternalServerErrorException extends RuntimeException {
+
 	private final ErrorCode code;
 
-	public CustomException(ErrorCode code) {
+	public InternalServerErrorException(ErrorCode code) {
 		super(code.getMessage());
 		this.code = code;
 	}

--- a/wingle/src/main/java/kr/co/wingle/common/exception/RestExceptionHandler.java
+++ b/wingle/src/main/java/kr/co/wingle/common/exception/RestExceptionHandler.java
@@ -1,13 +1,9 @@
 package kr.co.wingle.common.exception;
 
-import javax.servlet.http.HttpServletRequest;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import kr.co.wingle.common.constants.ErrorCode;
-import kr.co.wingle.common.dto.ApiResponse;
-import lombok.extern.slf4j.Slf4j;
+import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
@@ -18,12 +14,36 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import kr.co.wingle.common.constants.ErrorCode;
+import kr.co.wingle.common.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestControllerAdvice
 public class RestExceptionHandler {
 
-	@ExceptionHandler(CustomException.class)
-	protected ApiResponse<Object> handleCustomException(CustomException exception, HttpServletRequest request) {
+	// Custom Bad Request Error
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(BadRequestException.class)
+	protected ApiResponse<Object> handleBadRequestException(BadRequestException exception, HttpServletRequest request) {
+		logInfo(request, exception.getCode().getStatus(), exception.getCode().getMessage());
+		return ApiResponse.error(exception.getCode());
+	}
+
+	// Custom Unauthorized Error
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ExceptionHandler(UnauthorizedException.class)
+	protected ApiResponse<Object> handleUnauthorizedException(UnauthorizedException exception,
+		HttpServletRequest request) {
+		logInfo(request, exception.getCode().getStatus(), exception.getCode().getMessage());
+		return ApiResponse.error(exception.getCode());
+	}
+
+	// Custom Internal Server Error
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(InternalServerErrorException.class)
+	protected ApiResponse<Object> handleInternalServerErrorException(InternalServerErrorException exception,
+		HttpServletRequest request) {
 		logInfo(request, exception.getCode().getStatus(), exception.getCode().getMessage());
 		return ApiResponse.error(exception.getCode());
 	}

--- a/wingle/src/main/java/kr/co/wingle/common/exception/UnauthorizedException.java
+++ b/wingle/src/main/java/kr/co/wingle/common/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package kr.co.wingle.common.exception;
+
+import kr.co.wingle.common.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedException extends RuntimeException {
+	private final ErrorCode code;
+
+	public UnauthorizedException(ErrorCode code) {
+		super(code.getMessage());
+		this.code = code;
+	}
+}

--- a/wingle/src/main/java/kr/co/wingle/common/util/S3Util.java
+++ b/wingle/src/main/java/kr/co/wingle/common/util/S3Util.java
@@ -17,7 +17,8 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
 
 import kr.co.wingle.common.constants.ErrorCode;
-import kr.co.wingle.common.exception.CustomException;
+import kr.co.wingle.common.exception.BadRequestException;
+import kr.co.wingle.common.exception.InternalServerErrorException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -52,7 +53,7 @@ public class S3Util {
 			return upload(file, "idCardImage");
 		} catch (IOException e) {
 			log.warn(e.getMessage());
-			throw new CustomException(ErrorCode.FILE_UPLOAD_FAIL);
+			throw new InternalServerErrorException(ErrorCode.FILE_UPLOAD_FAIL);
 		}
 	}
 
@@ -61,7 +62,7 @@ public class S3Util {
 			return upload(file, "profileImage");
 		} catch (IOException e) {
 			log.warn(e.getMessage());
-			throw new CustomException(ErrorCode.FILE_UPLOAD_FAIL);
+			throw new InternalServerErrorException(ErrorCode.FILE_UPLOAD_FAIL);
 		}
 	}
 
@@ -90,7 +91,7 @@ public class S3Util {
 
 	private String getFileExtension(String fileName) {
 		if (!fileName.contains(".")) {
-			throw new CustomException(ErrorCode.BAD_FILE_NAME);
+			throw new BadRequestException(ErrorCode.BAD_FILE_NAME);
 		}
 		String fileExtension = fileName.substring(fileName.lastIndexOf("."));
 
@@ -98,7 +99,7 @@ public class S3Util {
 			|| fileExtension.equalsIgnoreCase(".png") || fileExtension.equalsIgnoreCase(".heic")) {
 			return fileExtension;
 		} else {
-			throw new CustomException(ErrorCode.BAD_FILE_EXTENSION);
+			throw new BadRequestException(ErrorCode.BAD_FILE_EXTENSION);
 		}
 	}
 }

--- a/wingle/src/main/java/kr/co/wingle/common/util/SecurityUtil.java
+++ b/wingle/src/main/java/kr/co/wingle/common/util/SecurityUtil.java
@@ -4,7 +4,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import kr.co.wingle.common.constants.ErrorCode;
-import kr.co.wingle.common.exception.CustomException;
+import kr.co.wingle.common.exception.UnauthorizedException;
 
 public class SecurityUtil {
 
@@ -15,7 +15,7 @@ public class SecurityUtil {
 		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
 		if (authentication == null || authentication.getName() == null) {
-			throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
+			throw new UnauthorizedException(ErrorCode.UNAUTHORIZED_USER);
 		}
 
 		return authentication.getName();

--- a/wingle/src/main/java/kr/co/wingle/common/util/StringUtil.java
+++ b/wingle/src/main/java/kr/co/wingle/common/util/StringUtil.java
@@ -3,7 +3,7 @@ package kr.co.wingle.common.util;
 import org.springframework.stereotype.Component;
 
 import kr.co.wingle.common.constants.ErrorCode;
-import kr.co.wingle.common.exception.CustomException;
+import kr.co.wingle.common.exception.BadRequestException;
 
 @Component
 public class StringUtil {
@@ -11,7 +11,7 @@ public class StringUtil {
 		try {
 			return Long.parseLong(string);
 		} catch (Exception e) {
-			throw new CustomException(ErrorCode.BAD_PARAMETER_TYPE);
+			throw new BadRequestException(ErrorCode.BAD_PARAMETER_TYPE);
 		}
 	}
 
@@ -19,7 +19,7 @@ public class StringUtil {
 		try {
 			return Integer.parseInt(string);
 		} catch (Exception e) {
-			throw new CustomException(ErrorCode.BAD_PARAMETER_TYPE);
+			throw new BadRequestException(ErrorCode.BAD_PARAMETER_TYPE);
 		}
 	}
 }

--- a/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/AuthService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import kr.co.wingle.common.constants.ErrorCode;
-import kr.co.wingle.common.exception.CustomException;
+import kr.co.wingle.common.exception.BadRequestException;
 import kr.co.wingle.common.exception.DuplicateException;
 import kr.co.wingle.common.exception.ForbiddenException;
 import kr.co.wingle.common.exception.NotFoundException;
@@ -98,7 +98,7 @@ public class AuthService {
 			if (profileUtil.isDuplicatedNicknameByMemberId(request.getNickname(), member.getId())) {
 				throw new DuplicateException(ErrorCode.DUPLICATE_NICKNAME);
 			}
-			
+
 			// save profile
 			Profile existProfile = profileRepository.findByMember(member).get();
 			profile = Profile.copyProfile(profile, existProfile);
@@ -209,7 +209,7 @@ public class AuthService {
 		}
 
 		if (Integer.parseInt(redisUtil.getData(attemptEmailKey)) > 5) {
-			throw new CustomException(ErrorCode.TOO_MANY_EMAIL_REQUEST);
+			throw new BadRequestException(ErrorCode.TOO_MANY_EMAIL_REQUEST);
 		}
 
 		String certificationKey = mailService.sendEmail(to, new CodeMail());
@@ -221,9 +221,9 @@ public class AuthService {
 		String inputCode = certificationRequestDto.getCertificationCode();
 		String code = redisUtil.getData(email);
 		if (code == null)
-			throw new CustomException(ErrorCode.NO_EMAIL_CODE);
+			throw new BadRequestException(ErrorCode.NO_EMAIL_CODE);
 		if (!code.equals(inputCode))
-			throw new CustomException(ErrorCode.INCONSISTENT_CODE);
+			throw new BadRequestException(ErrorCode.INCONSISTENT_CODE);
 		return CertificationResponseDto.of(true);
 	}
 
@@ -232,7 +232,7 @@ public class AuthService {
 		Long userId = acceptanceRequestDto.getUserId();
 		Member member = memberService.findMemberByMemberId(userId);
 		if (member.getPermission() == Permission.APPROVE.getStatus())
-			throw new CustomException(ErrorCode.ALREADY_ACCEPTANCE);
+			throw new BadRequestException(ErrorCode.ALREADY_ACCEPTANCE);
 
 		member.setPermission(Permission.APPROVE.getStatus());
 		mailService.sendEmail(member.getEmail(), new AcceptanceMail(member.getName()));
@@ -244,9 +244,9 @@ public class AuthService {
 		Long userId = rejectionRequestDto.getUserId();
 		Member member = memberService.findMemberByMemberId(userId);
 		if (member.getPermission() == Permission.DENY.getStatus())
-			throw new CustomException(ErrorCode.ALREADY_DENY);
+			throw new BadRequestException(ErrorCode.ALREADY_DENY);
 		if (member.getPermission() == Permission.APPROVE.getStatus())
-			throw new CustomException(ErrorCode.ALREADY_ACCEPTANCE);
+			throw new BadRequestException(ErrorCode.ALREADY_ACCEPTANCE);
 
 		member.setPermission(Permission.DENY.getStatus());
 		memberService.saveRejectionReason(rejectionRequestDto);

--- a/wingle/src/main/java/kr/co/wingle/member/service/MailService.java
+++ b/wingle/src/main/java/kr/co/wingle/member/service/MailService.java
@@ -16,7 +16,7 @@ import org.thymeleaf.spring5.SpringTemplateEngine;
 
 import kr.co.wingle.common.config.MailConfig;
 import kr.co.wingle.common.constants.ErrorCode;
-import kr.co.wingle.common.exception.CustomException;
+import kr.co.wingle.common.exception.BadRequestException;
 import kr.co.wingle.common.util.RedisUtil;
 import kr.co.wingle.member.mailVo.CodeMail;
 import kr.co.wingle.member.mailVo.Mail;
@@ -45,7 +45,7 @@ public class MailService {
 		} catch (MailException | MessagingException | UnsupportedEncodingException es) {
 			log.error(es.getMessage());
 			log.error(es.getStackTrace().toString());
-			throw new CustomException(ErrorCode.EMAIL_SEND_FAIL);
+			throw new BadRequestException(ErrorCode.EMAIL_SEND_FAIL);
 		}
 		return to;
 	}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 테스트 코드가 잘 통과되나요?
- [x] 이 프로젝트의 코드 스타일을 따르나요?
- [x] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [x] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
CustomException http status별로 분리
- 500 http status 쓰는 에러 -> InternalServerErrorException으로 분리
- 401 http status 쓰는 에러 -> UnauthorizedException으로 분리
- 기존 CustomException -> BadRequestException으로 수정

resolved: #210 
