### PR TITLE
Fix/익명게시판 사용자 구분 #224

### DIFF
--- a/wingle/src/main/java/kr/co/wingle/community/article/ArticleMapper.java
+++ b/wingle/src/main/java/kr/co/wingle/community/article/ArticleMapper.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import kr.co.wingle.common.util.AES256Util;
 import kr.co.wingle.community.util.CommunityUtil;
 import kr.co.wingle.community.util.ProcessedPersonalInformation;
 import kr.co.wingle.profile.ProfileService;
@@ -36,9 +35,7 @@ public class ArticleMapper {
 		if (list != null) {
 			articleResponseDto.images(new ArrayList<String>(list));
 		}
-		articleResponseDto.isMine(processedPersonalInformation.isMine());
-		articleResponseDto.userId(
-			AES256Util.encrypt(article.getMember().getId().toString(), article.getId().toString()));
+		articleResponseDto.userId(processedPersonalInformation.getProcessedMemberId());
 		articleResponseDto.userImage(profileService.getProfileByMemberId(article.getMember().getId()).getImageUrl());
 		articleResponseDto.userNation(profileService.getProfileByMemberId(article.getMember().getId()).getNation());
 		articleResponseDto.userSchoolName(processedPersonalInformation.getSchoolName());

--- a/wingle/src/main/java/kr/co/wingle/community/article/ArticleMapper.java
+++ b/wingle/src/main/java/kr/co/wingle/community/article/ArticleMapper.java
@@ -25,13 +25,12 @@ public class ArticleMapper {
 
 		ArticleResponseDto.ArticleResponseDtoBuilder articleResponseDto = ArticleResponseDto.builder();
 
-		if (article != null) {
-			articleResponseDto.articleId(article.getId());
-			articleResponseDto.createdTime(article.getCreatedTime());
-			articleResponseDto.updatedTime(article.getUpdatedTime());
-			articleResponseDto.content(article.getContent());
-			articleResponseDto.likeCount(article.getLikeCount());
-		}
+		articleResponseDto.articleId(article.getId());
+		articleResponseDto.createdTime(article.getCreatedTime());
+		articleResponseDto.updatedTime(article.getUpdatedTime());
+		articleResponseDto.content(article.getContent());
+		articleResponseDto.likeCount(article.getLikeCount());
+
 		articleResponseDto.userNickname(processedPersonalInformation.getNickname());
 		List<String> list = images;
 		if (list != null) {
@@ -43,7 +42,9 @@ public class ArticleMapper {
 		articleResponseDto.userImage(profileService.getProfileByMemberId(article.getMember().getId()).getImageUrl());
 		articleResponseDto.userNation(profileService.getProfileByMemberId(article.getMember().getId()).getNation());
 		articleResponseDto.userSchoolName(processedPersonalInformation.getSchoolName());
+
 		articleResponseDto.forumId(article.getForum().getId());
+		articleResponseDto.isMine(processedPersonalInformation.isMine());
 
 		return articleResponseDto.build();
 	}

--- a/wingle/src/main/java/kr/co/wingle/community/comment/CommentMapper.java
+++ b/wingle/src/main/java/kr/co/wingle/community/comment/CommentMapper.java
@@ -2,7 +2,6 @@ package kr.co.wingle.community.comment;
 
 import org.springframework.stereotype.Component;
 
-import kr.co.wingle.common.util.AES256Util;
 import kr.co.wingle.community.util.CommunityUtil;
 import kr.co.wingle.community.util.ProcessedPersonalInformation;
 import kr.co.wingle.profile.ProfileService;
@@ -22,8 +21,7 @@ public class CommentMapper {
 		CommentResponseDto.CommentResponseDtoBuilder commentResponseDto = CommentResponseDto.builder();
 
 		commentResponseDto.id(comment.getId());
-		commentResponseDto.userId(
-			AES256Util.encrypt(comment.getMember().getId().toString(), comment.getArticle().getId().toString()));
+		commentResponseDto.userId(processedPersonalInformation.getProcessedMemberId());
 		commentResponseDto.userNickname(processedPersonalInformation.getNickname());
 		commentResponseDto.userImage(profileService.getProfileByMemberId(comment.getMember().getId()).getImageUrl());
 		commentResponseDto.userNation(profileService.getProfileByMemberId(comment.getMember().getId()).getNation());

--- a/wingle/src/main/java/kr/co/wingle/community/util/ProcessedPersonalInformation.java
+++ b/wingle/src/main/java/kr/co/wingle/community/util/ProcessedPersonalInformation.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProcessedPersonalInformation {
 	private String nickname;
-	private Long processedMemberId;
+	private String processedMemberId;
 	private String schoolName;
 	private boolean isMine;
 
-	public static ProcessedPersonalInformation of(String nickname, Long processedMemberId, String schoolName,
+	public static ProcessedPersonalInformation of(String nickname, String processedMemberId, String schoolName,
 		boolean isMine) {
 		return new ProcessedPersonalInformation(nickname, processedMemberId, schoolName, isMine);
 	}


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 테스트 코드가 잘 통과되나요?
- [ ] 이 프로젝트의 코드 스타일을 따르나요?
- [ ] 문서변경이 필요한 경우, 변경하였나요?

## 📋 변경 유형
- [ ] Bug
- [ ] Feature
- [ ] Breaking change (기존 기능을 변경하게 하는 bug 또는 feature)

## ✏️ PR 개요
- 익명게시판 사용자 구분 수정
  익명게시판인 경우에만 salt를 이용한 암호화 진행하도록 수정함.
  실명게시판에서 타인 프로필을 클릭해 프로필 조회 시에 memberId를 복호화해야 하는데, 이때 salt값(=articleId)를 전달받을 수 없으므로
  실명게시판에서는 salt를 사용하지 않은 암호화를 할 필요성이 있었음.

resolved: #이슈번호
